### PR TITLE
Save and load reports from AsyncStorage (#13, #16)

### DIFF
--- a/codesign/app/(tabs)/_layout.tsx
+++ b/codesign/app/(tabs)/_layout.tsx
@@ -7,6 +7,7 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { TAB_ROUTES } from '@/constants/Routes';
 
 const TAB_BAR_HEIGHT = 90;
 const TAB_BAR_GAP = 5;
@@ -54,7 +55,7 @@ export default function TabLayout() {
       }}
     >
       <Tabs.Screen
-        name="index"
+        name={TAB_ROUTES.INDEX}
         options={{
           title: 'View Map',
           tabBarIcon: ({ color }) => (
@@ -63,7 +64,7 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="report"
+        name={TAB_ROUTES.REPORT}
         options={{
           title: 'Create Report',
           tabBarIcon: ({ color }) => (
@@ -72,7 +73,7 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="profile"
+        name={TAB_ROUTES.PROFILE}
         options={{
           title: 'Profile',
           tabBarIcon: ({ color }) => (

--- a/codesign/app/(tabs)/index.tsx
+++ b/codesign/app/(tabs)/index.tsx
@@ -1,18 +1,83 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Image } from 'react-native';
 
 import { ThemedView } from '@/components/ThemedView';
 import { MapView } from '@/components/map/MapView';
 import { Layout } from '@/constants/styles/Layout';
 import { useCodesignData } from '@/components/CodesignDataProvider';
+import { MarkerView } from '@/components/map/MarkerView';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export type MapDataPoint = {
+  id: string;
+  coordinates: number[];
+  name: string;
+};
+
+const REPORT_COORDS: MapDataPoint[] = [
+  {
+    id: '1',
+    coordinates: [-96.34058678893092, 30.61452419398209],
+    name: 'Hart Hall'
+  },
+  {
+    id: '2',
+    coordinates: [-96.33890180386302, 30.617351074711575],
+    name: 'Sterling C. Evans Library'
+  },
+  {
+    id: '3',
+    coordinates: [-96.34415881904341, 30.615708632774894],
+    name: 'McFadden Hall'
+  },
+  {
+    id: '4',
+    coordinates: [-96.35119602985726, 30.607255922217114],
+    name: 'The Gardens at TAMU'
+  },
+  {
+    id: '5',
+    coordinates: [-96.34679890280329, 30.60260129978098],
+    name: 'Memorial Student Center'
+  },
+  {
+    id: '6',
+    coordinates: [-96.3461850646517, 30.611058409443608],
+    name: 'Instructional Laboratory & Innovative Learning Building'
+  }
+];
+
+const REPORT_ICON_SRC = {
+  light: require('@/assets/images/custom-form-icon-light.png'),
+  dark: require('@/assets/images/custom-form-icon-dark.png')
+};
 
 export default function HomeScreen() {
+  const colorScheme = (useColorScheme() ?? 'light') as 'light' | 'dark';
+
   const { reports } = useCodesignData();
 
   return (
     <ThemedView style={styles.titleContainer}>
-      <MapView style={[Layout.flex]} />
+      <MapView style={[Layout.flex]}>
+        {REPORT_COORDS.map((point) => (
+          <MarkerView
+            key={point.id}
+            coordinates={point.coordinates}
+            onPress={() => alertLocation(point.name)}
+          >
+            <Image
+              source={REPORT_ICON_SRC[colorScheme]}
+              style={styles.reportImage}
+            />
+          </MarkerView>
+        ))}
+      </MapView>
     </ThemedView>
   );
+}
+
+function alertLocation(name: string) {
+  alert(`Marker Pressed for ${name}`);
 }
 
 const styles = StyleSheet.create({
@@ -21,5 +86,9 @@ const styles = StyleSheet.create({
   },
   map: {
     flex: 1
+  },
+  reportImage: {
+    width: 25,
+    height: 30
   }
 });

--- a/codesign/app/(tabs)/index.tsx
+++ b/codesign/app/(tabs)/index.tsx
@@ -7,45 +7,6 @@ import { useCodesignData } from '@/components/CodesignDataProvider';
 import { MarkerView } from '@/components/map/MarkerView';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
-export type MapDataPoint = {
-  id: string;
-  coordinates: number[];
-  name: string;
-};
-
-const REPORT_COORDS: MapDataPoint[] = [
-  {
-    id: '1',
-    coordinates: [-96.34058678893092, 30.61452419398209],
-    name: 'Hart Hall'
-  },
-  {
-    id: '2',
-    coordinates: [-96.33890180386302, 30.617351074711575],
-    name: 'Sterling C. Evans Library'
-  },
-  {
-    id: '3',
-    coordinates: [-96.34415881904341, 30.615708632774894],
-    name: 'McFadden Hall'
-  },
-  {
-    id: '4',
-    coordinates: [-96.35119602985726, 30.607255922217114],
-    name: 'The Gardens at TAMU'
-  },
-  {
-    id: '5',
-    coordinates: [-96.34679890280329, 30.60260129978098],
-    name: 'Memorial Student Center'
-  },
-  {
-    id: '6',
-    coordinates: [-96.3461850646517, 30.611058409443608],
-    name: 'Instructional Laboratory & Innovative Learning Building'
-  }
-];
-
 const REPORT_ICON_SRC = {
   light: require('@/assets/images/custom-form-icon-light.png'),
   dark: require('@/assets/images/custom-form-icon-dark.png')
@@ -55,22 +16,24 @@ export default function HomeScreen() {
   const colorScheme = (useColorScheme() ?? 'light') as 'light' | 'dark';
 
   const { reports } = useCodesignData();
+  const isReportsEmpty = reports.length === 0;
 
   return (
     <ThemedView style={styles.titleContainer}>
       <MapView style={[Layout.flex]}>
-        {REPORT_COORDS.map((point) => (
-          <MarkerView
-            key={point.id}
-            coordinates={point.coordinates}
-            onPress={() => alertLocation(point.name)}
-          >
-            <Image
-              source={REPORT_ICON_SRC[colorScheme]}
-              style={styles.reportImage}
-            />
-          </MarkerView>
-        ))}
+        {!isReportsEmpty &&
+          reports.map((report) => (
+            <MarkerView
+              key={report.getId()}
+              coordinates={report.getCoordinates()}
+              onPress={() => alertLocation(report.getTitle())}
+            >
+              <Image
+                source={REPORT_ICON_SRC[colorScheme]}
+                style={styles.reportImage}
+              />
+            </MarkerView>
+          ))}
       </MapView>
     </ThemedView>
   );

--- a/codesign/app/(tabs)/index.tsx
+++ b/codesign/app/(tabs)/index.tsx
@@ -3,8 +3,11 @@ import { StyleSheet } from 'react-native';
 import { ThemedView } from '@/components/ThemedView';
 import { MapView } from '@/components/map/MapView';
 import { Layout } from '@/constants/styles/Layout';
+import { useCodesignData } from '@/components/CodesignDataProvider';
 
 export default function HomeScreen() {
+  const { reports } = useCodesignData();
+
   return (
     <ThemedView style={styles.titleContainer}>
       <MapView style={[Layout.flex]} />

--- a/codesign/app/_layout.tsx
+++ b/codesign/app/_layout.tsx
@@ -13,6 +13,7 @@ import Constants from 'expo-constants';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useFonts } from '@/hooks/useFonts';
+import { CodesignDataProvider } from '@/components/CodesignDataProvider';
 
 // Set the access token from app.json
 MapboxGL.setAccessToken(Constants.expoConfig?.extra?.mapboxAccessToken ?? '');
@@ -21,7 +22,7 @@ MapboxGL.setTelemetryEnabled(false);
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
-export default function RootLayout() {
+function App({ children }: { children: React.ReactNode }) {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts();
 
@@ -36,12 +37,22 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <CodesignDataProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        {children}
+      </ThemeProvider>
+    </CodesignDataProvider>
+  );
+}
+
+export default function RootLayout() {
+  return (
+    <App>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />
-    </ThemeProvider>
+    </App>
   );
 }

--- a/codesign/components/CodesignDataProvider.tsx
+++ b/codesign/components/CodesignDataProvider.tsx
@@ -1,0 +1,81 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { Report } from '@/types/Report';
+import {
+  setReportsLocal,
+  getReportsLocal
+} from '@/utils/report/saveReportLocal';
+import { createReportMockData } from '@/utils/report/createReportMockData';
+
+type CodesignDataContextType = {
+  reports: Report[];
+  setReports: (reports: Report[]) => void;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const CodesignDataContext = createContext<CodesignDataContextType | undefined>(
+  undefined
+);
+
+// Custom hook to access context
+export const useCodesignData = () => {
+  const context = useContext(CodesignDataContext);
+  if (!context) {
+    throw new Error('useData must be used within a CodesignDataProvider');
+  }
+  return context;
+};
+
+export const CodesignDataProvider = ({
+  children
+}: {
+  children: React.ReactNode;
+}) => {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch reports on component mount
+  useEffect(() => {
+    // This is where a GET request would be made to fetch reports
+    // for now, we will just initialize the reports locally from AsyncStorage or use mock data
+    getReportsLocal()
+      .then((reports: Report[]) => {
+        if (reports.length === 0) {
+          throw new Error(
+            'No reports from AsyncStorage so initializing with mock data'
+          );
+        }
+        setReports(reports);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        const REPORT_DATA: Report[] = [
+          createReportMockData(),
+          createReportMockData(),
+          createReportMockData()
+        ];
+        setReportsLocal(REPORT_DATA)
+          .then(() => {
+            setReports(REPORT_DATA);
+            setIsLoading(false);
+          })
+          .catch((err) => {
+            setError(err);
+          });
+      });
+  }, []);
+
+  // sync reports with AsyncStorage
+  useEffect(() => {
+    setReportsLocal(reports);
+  }, [reports]);
+
+  return (
+    <CodesignDataContext.Provider
+      value={{ reports, setReports, isLoading, error }}
+    >
+      {children}
+    </CodesignDataContext.Provider>
+  );
+};

--- a/codesign/components/map/MapView.tsx
+++ b/codesign/components/map/MapView.tsx
@@ -1,90 +1,28 @@
-import { type ViewProps, StyleSheet, Image } from 'react-native';
+import { type ViewProps } from 'react-native';
 import MapboxGL, { Camera, StyleURL } from '@rnmapbox/maps';
 
-import { MarkerView } from '@/components/map/MarkerView';
 import { useColorScheme } from '@/hooks/useColorScheme';
-
-export type MapDataPoint = {
-  id: string;
-  coordinates: number[];
-  name: string;
-};
 
 type LocalMapViewProps = {
   style?: ViewProps['style'];
+  children?: React.ReactNode;
+  centerCoords?: number[];
 };
-
-// TO DO: Replace with actual report data
-const REPORT_COORDS: MapDataPoint[] = [
-  {
-    id: '1',
-    coordinates: [-96.34058678893092, 30.61452419398209],
-    name: 'Hart Hall'
-  },
-  {
-    id: '2',
-    coordinates: [-96.33890180386302, 30.617351074711575],
-    name: 'Sterling C. Evans Library'
-  },
-  {
-    id: '3',
-    coordinates: [-96.34415881904341, 30.615708632774894],
-    name: 'McFadden Hall'
-  },
-  {
-    id: '4',
-    coordinates: [-96.35119602985726, 30.607255922217114],
-    name: 'The Gardens at TAMU'
-  },
-  {
-    id: '5',
-    coordinates: [-96.34679890280329, 30.60260129978098],
-    name: 'Memorial Student Center'
-  },
-  {
-    id: '6',
-    coordinates: [-96.3461850646517, 30.611058409443608],
-    name: 'Instructional Laboratory & Innovative Learning Building'
-  }
-];
 
 const CENTER_COORDS = [-96.3446075505438, 30.613381329387035]; // Centered on Albritton Bell Tower
 
-const REPORT_ICON_SRC = {
-  light: require('@/assets/images/custom-form-icon-light.png'),
-  dark: require('@/assets/images/custom-form-icon-dark.png')
-};
-
-export function MapView({ style }: LocalMapViewProps) {
+export function MapView({
+  style,
+  children,
+  centerCoords = CENTER_COORDS
+}: LocalMapViewProps) {
   const colorScheme = (useColorScheme() ?? 'light') as 'light' | 'dark';
   const styleURL = colorScheme === 'light' ? StyleURL.Light : StyleURL.Dark;
 
   return (
     <MapboxGL.MapView style={[style]} styleURL={styleURL}>
-      <Camera zoomLevel={14} centerCoordinate={CENTER_COORDS} />
-      {REPORT_COORDS.map((point) => (
-        <MarkerView
-          key={point.id}
-          point={point}
-          onPress={() => alertLocation(point.name)}
-        >
-          <Image
-            source={REPORT_ICON_SRC[colorScheme]}
-            style={styles.reportImage}
-          />
-        </MarkerView>
-      ))}
+      <Camera zoomLevel={14} centerCoordinate={centerCoords} />
+      {children}
     </MapboxGL.MapView>
   );
-}
-
-const styles = StyleSheet.create({
-  reportImage: {
-    width: 25,
-    height: 30
-  }
-});
-
-function alertLocation(name: string) {
-  alert(`Marker Pressed for ${name}`);
 }

--- a/codesign/components/map/MapView.tsx
+++ b/codesign/components/map/MapView.tsx
@@ -2,6 +2,7 @@ import { type ViewProps } from 'react-native';
 import MapboxGL, { Camera, StyleURL } from '@rnmapbox/maps';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { ALBRITTON_BELL_TOWER } from '@/constants/map/Coordinates';
 
 type LocalMapViewProps = {
   style?: ViewProps['style'];
@@ -9,12 +10,10 @@ type LocalMapViewProps = {
   centerCoords?: number[];
 };
 
-const CENTER_COORDS = [-96.3446075505438, 30.613381329387035]; // Centered on Albritton Bell Tower
-
 export function MapView({
   style,
   children,
-  centerCoords = CENTER_COORDS
+  centerCoords = ALBRITTON_BELL_TOWER
 }: LocalMapViewProps) {
   const colorScheme = (useColorScheme() ?? 'light') as 'light' | 'dark';
   const styleURL = colorScheme === 'light' ? StyleURL.Light : StyleURL.Dark;

--- a/codesign/components/map/MarkerView.tsx
+++ b/codesign/components/map/MarkerView.tsx
@@ -4,22 +4,21 @@ import { PropsWithChildren } from 'react';
 
 import { ThemedView } from '@/components/ThemedView';
 import { tamuColors } from '@/constants/Colors';
-import { MapDataPoint } from '@/components/map/MapView';
 
 type MarkerViewProps = PropsWithChildren<{
   style?: ViewProps['style'];
-  point: MapDataPoint;
+  coordinates: number[];
   onPress?: () => void;
 }>;
 
 export function MarkerView({
   children,
   style,
-  point,
+  coordinates,
   onPress
 }: MarkerViewProps) {
   return (
-    <MapboxGL.MarkerView coordinate={point.coordinates}>
+    <MapboxGL.MarkerView coordinate={coordinates}>
       <Pressable style={[styles.markerContainer, style]} onPress={onPress}>
         <ThemedView style={styles.marker}>{children}</ThemedView>
       </Pressable>

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -34,7 +34,7 @@ export function ReportForm({ style }: ViewProps) {
   const router = useRouter();
   const { reports, setReports } = useCodesignData();
 
-  const { control, handleSubmit, watch, setValue, formState } = useForm({
+  const { control, handleSubmit, watch, setValue, formState, reset } = useForm({
     defaultValues: DefaultIndoorReport
   });
 
@@ -59,13 +59,15 @@ export function ReportForm({ style }: ViewProps) {
         });
         setReports([...reports, newReport]);
 
-        // TO DO: Reset form after submitting
+        reset();
 
         // Navigate to the Map tab
         router.replace({ pathname: TAB_ROUTE_PATH[TAB_ROUTES.INDEX] });
+
+        // TO DO #24 : Add success modal
       })
       .catch((error) => {
-        // TO DO: Show an error on the form
+        // TO DO #24: Show an error on the form
       });
   };
 
@@ -233,6 +235,7 @@ export function ReportForm({ style }: ViewProps) {
             type="tertiary"
             smallCaps={false}
             textStyle={styles.clearFormButton}
+            onPress={() => reset()}
           />
           <TextButton
             text="Submit"

--- a/codesign/constants/Routes.ts
+++ b/codesign/constants/Routes.ts
@@ -1,0 +1,13 @@
+import { RelativePathString } from 'expo-router';
+
+export const TAB_ROUTES = {
+  INDEX: 'index',
+  REPORT: 'report',
+  PROFILE: 'profile'
+};
+
+export const TAB_ROUTE_PATH = {
+  [TAB_ROUTES.INDEX]: '/',
+  [TAB_ROUTES.REPORT]: '/report',
+  [TAB_ROUTES.PROFILE]: '/profile'
+} as Record<string, RelativePathString>;

--- a/codesign/constants/map/Coordinates.ts
+++ b/codesign/constants/map/Coordinates.ts
@@ -1,0 +1,5 @@
+import { Coordinates } from '@/types/Report';
+
+export const ALBRITTON_BELL_TOWER = [
+  -96.3446075505438, 30.613381329387035
+] as Coordinates;

--- a/codesign/constants/report/Report.ts
+++ b/codesign/constants/report/Report.ts
@@ -3,6 +3,7 @@ import {
   ReportType,
   ReportLocationType
 } from '@/types/Report';
+import { ALBRITTON_BELL_TOWER } from '@/constants/map/Coordinates';
 
 export const DefaultIndoorReport: ReportFormDetails = {
   id: -1,
@@ -16,7 +17,7 @@ export const DefaultIndoorReport: ReportFormDetails = {
       floorNumber: 1
     }
   },
-  geoCoordinates: [],
+  coordinates: ALBRITTON_BELL_TOWER,
   createdAt: new Date()
 };
 
@@ -27,6 +28,6 @@ export const DefaultOutdoorReport: ReportFormDetails = {
   title: '',
   description: '',
   reportLocationDetails: {},
-  geoCoordinates: [],
+  coordinates: ALBRITTON_BELL_TOWER,
   createdAt: new Date()
 };

--- a/codesign/constants/report/Report.ts
+++ b/codesign/constants/report/Report.ts
@@ -5,6 +5,7 @@ import {
 } from '@/types/Report';
 
 export const DefaultIndoorReport: ReportFormDetails = {
+  id: -1,
   reportType: ReportType.MAINTENANCE,
   reportLocation: ReportLocationType.INDOOR,
   title: '',
@@ -14,13 +15,18 @@ export const DefaultIndoorReport: ReportFormDetails = {
       buildingName: '',
       floorNumber: 1
     }
-  }
+  },
+  geoCoordinates: [],
+  createdAt: new Date()
 };
 
 export const DefaultOutdoorReport: ReportFormDetails = {
+  id: -1,
   reportType: ReportType.MAINTENANCE,
   reportLocation: ReportLocationType.OUTDOOR,
   title: '',
   description: '',
-  reportLocationDetails: {}
+  reportLocationDetails: {},
+  geoCoordinates: [],
+  createdAt: new Date()
 };

--- a/codesign/hooks/report/createReport.ts
+++ b/codesign/hooks/report/createReport.ts
@@ -1,9 +1,13 @@
 import { ReportFormDetails } from '@/types/Report';
 
-const createReport = (data: ReportFormDetails) => {
+async function createReport(data: ReportFormDetails) {
+  console.log('createReport');
   console.log(data);
 
   // This is where you would make a request to your API to create the report
-};
+  // Backend returns an id associated with the report
+  const id = Math.floor(Math.random() * 1000);
+  return { id };
+}
 
 export default createReport;

--- a/codesign/hooks/report/createReport.ts
+++ b/codesign/hooks/report/createReport.ts
@@ -1,13 +1,14 @@
 import { ReportFormDetails } from '@/types/Report';
 
 async function createReport(data: ReportFormDetails) {
-  console.log('createReport');
-  console.log(data);
-
-  // This is where you would make a request to your API to create the report
-  // Backend returns an id associated with the report
-  const id = Math.floor(Math.random() * 1000);
-  return { id };
+  try {
+    // This is where you would make a request to your API to create the report
+    // Backend returns an id associated with the report
+    const id = Math.floor(Math.random() * 1000);
+    return { id };
+  } catch {
+    throw new Error('Failed to create report');
+  }
 }
 
 export default createReport;

--- a/codesign/package-lock.json
+++ b/codesign/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.2",
+        "@react-native-async-storage/async-storage": "1.23.1",
         "@react-navigation/bottom-tabs": "^7.0.0",
         "@react-navigation/native": "^7.0.0",
         "@rnmapbox/maps": "^10.1.33",
@@ -3602,6 +3603,18 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
+      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -10039,6 +10052,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -12018,6 +12040,18 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/codesign/package.json
+++ b/codesign/package.json
@@ -44,7 +44,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
-    "react-refresh": "^0.16.0"
+    "react-refresh": "^0.16.0",
+    "@react-native-async-storage/async-storage": "1.23.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/codesign/types/Report.ts
+++ b/codesign/types/Report.ts
@@ -8,7 +8,9 @@ export enum ReportLocationType {
   'OUTDOOR' = 'OUTDOOR'
 }
 
-type ReportLocationDetails = {
+export type Coordinates = [number, number];
+
+export type ReportLocationDetails = {
   indoorDetails?: IndoorDetails;
 };
 
@@ -23,7 +25,7 @@ export type ReportFormDetails = {
   reportLocation: ReportLocationType;
   title: string;
   description: string;
-  geoCoordinates: number[];
+  coordinates: Coordinates;
   reportLocationDetails: ReportLocationDetails;
   createdAt: Date;
 };
@@ -34,7 +36,7 @@ export class Report implements ReportFormDetails {
   reportLocation: ReportLocationType;
   title: string;
   description: string;
-  geoCoordinates: number[];
+  coordinates: Coordinates;
   reportLocationDetails: ReportLocationDetails;
   createdAt: Date;
 
@@ -44,7 +46,7 @@ export class Report implements ReportFormDetails {
     this.reportLocation = reportDetails.reportLocation;
     this.title = reportDetails.title;
     this.description = reportDetails.description;
-    this.geoCoordinates = reportDetails.geoCoordinates;
+    this.coordinates = reportDetails.coordinates;
     this.reportLocationDetails = reportDetails.reportLocationDetails;
     this.createdAt = reportDetails.createdAt;
   }
@@ -69,8 +71,8 @@ export class Report implements ReportFormDetails {
     return this.description;
   }
 
-  getGeoCoordinates(): number[] {
-    return this.geoCoordinates;
+  getCoordinates(): number[] {
+    return this.coordinates;
   }
 
   getReportLocationDetails(): ReportLocationDetails {

--- a/codesign/types/Report.ts
+++ b/codesign/types/Report.ts
@@ -18,10 +18,92 @@ type IndoorDetails = {
 };
 
 export type ReportFormDetails = {
+  id: number;
   reportType: ReportType;
   reportLocation: ReportLocationType;
   title: string;
   description: string;
+  geoCoordinates: number[];
   reportLocationDetails: ReportLocationDetails;
-  createdAt?: Date;
+  createdAt: Date;
 };
+
+export class Report implements ReportFormDetails {
+  id: number;
+  reportType: ReportType;
+  reportLocation: ReportLocationType;
+  title: string;
+  description: string;
+  geoCoordinates: number[];
+  reportLocationDetails: ReportLocationDetails;
+  createdAt: Date;
+
+  constructor(reportDetails: ReportFormDetails) {
+    this.id = reportDetails.id;
+    this.reportType = reportDetails.reportType;
+    this.reportLocation = reportDetails.reportLocation;
+    this.title = reportDetails.title;
+    this.description = reportDetails.description;
+    this.geoCoordinates = reportDetails.geoCoordinates;
+    this.reportLocationDetails = reportDetails.reportLocationDetails;
+    this.createdAt = reportDetails.createdAt;
+  }
+
+  getId(): number {
+    return this.id;
+  }
+
+  getReportType(): ReportType {
+    return this.reportType;
+  }
+
+  getReportLocation(): ReportLocationType {
+    return this.reportLocation;
+  }
+
+  getTitle(): string {
+    return this.title;
+  }
+
+  getDescription(): string {
+    return this.description;
+  }
+
+  getGeoCoordinates(): number[] {
+    return this.geoCoordinates;
+  }
+
+  getReportLocationDetails(): ReportLocationDetails {
+    return this.reportLocationDetails;
+  }
+
+  getCreatedAt(): Date {
+    return this.createdAt;
+  }
+
+  isIndoor(): boolean {
+    return this.reportLocation === ReportLocationType.INDOOR;
+  }
+
+  isOutdoor(): boolean {
+    return this.reportLocation === ReportLocationType.OUTDOOR;
+  }
+
+  // May be called only when the report location is indoor
+  getBuildingName(): string {
+    if (this.reportLocation !== ReportLocationType.INDOOR) {
+      throw new Error('Report location is not indoor');
+    }
+
+    return this.reportLocationDetails.indoorDetails!.buildingName;
+  }
+
+  // May be called only when the report location is indoor
+  getFloorNumber(): number | undefined {
+    if (this.reportLocation !== ReportLocationType.INDOOR) {
+      throw new Error('Report location is not indoor');
+    }
+
+    return this.reportLocationDetails.indoorDetails!.floorNumber;
+  }
+}

--- a/codesign/utils/Math.ts
+++ b/codesign/utils/Math.ts
@@ -1,0 +1,3 @@
+export function getRandomNumber(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
+}

--- a/codesign/utils/report/createReportMockData.ts
+++ b/codesign/utils/report/createReportMockData.ts
@@ -6,6 +6,13 @@ import {
 } from '@/types/Report';
 import { getRandomNumber } from '../Math';
 
+export const createRandomCoordinates = (): Coordinates => {
+  return [
+    getRandomNumber(-96.35119602985726, -96.33890180386302),
+    getRandomNumber(30.607255922217114, 30.617351074711575)
+  ] as Coordinates;
+};
+
 export function createReportMockData(report = {}): Report {
   // Randomly select a location
   const reportLocation =
@@ -21,10 +28,7 @@ export function createReportMockData(report = {}): Report {
           }
         }
       : {};
-  const coordinates = [
-    getRandomNumber(-96.35119602985726, -96.33890180386302),
-    getRandomNumber(30.607255922217114, 30.617351074711575)
-  ] as Coordinates;
+  const coordinates = createRandomCoordinates();
   const reportData = new Report({
     id: Math.floor(Math.random() * 1000),
     reportType: ReportType.MAINTENANCE,

--- a/codesign/utils/report/createReportMockData.ts
+++ b/codesign/utils/report/createReportMockData.ts
@@ -1,0 +1,36 @@
+import { ReportLocationType, ReportType, Report } from '@/types/Report';
+import { getRandomNumber } from '../Math';
+
+export function createReportMockData(report = {}): Report {
+  // Randomly select a location
+  const reportLocation =
+    Math.random() < 0.5
+      ? ReportLocationType.INDOOR
+      : ReportLocationType.OUTDOOR;
+  const reportLocationDetails =
+    reportLocation === ReportLocationType.INDOOR
+      ? {
+          indoorDetails: {
+            buildingName: 'Building ABC',
+            floorNumber: 1
+          }
+        }
+      : {};
+  const geoCoordinates = [
+    getRandomNumber(37.7749, 37.7751), // longitude
+    getRandomNumber(-122.4194, -122.4196) // latitude
+  ];
+  const reportData = new Report({
+    id: Math.floor(Math.random() * 1000),
+    reportType: ReportType.MAINTENANCE,
+    title: 'Crack in the pavement by the bus stop',
+    description:
+      'While I was walking to the bus top to take bus 47, I noticed that there is a crack in the pavement by the bus stop. It makes it pretty easy for people to trip over it and fall.',
+    reportLocation,
+    reportLocationDetails,
+    geoCoordinates,
+    createdAt: new Date(),
+    ...report
+  });
+  return reportData;
+}

--- a/codesign/utils/report/createReportMockData.ts
+++ b/codesign/utils/report/createReportMockData.ts
@@ -1,4 +1,9 @@
-import { ReportLocationType, ReportType, Report } from '@/types/Report';
+import {
+  ReportLocationType,
+  ReportType,
+  Report,
+  Coordinates
+} from '@/types/Report';
 import { getRandomNumber } from '../Math';
 
 export function createReportMockData(report = {}): Report {
@@ -16,10 +21,10 @@ export function createReportMockData(report = {}): Report {
           }
         }
       : {};
-  const geoCoordinates = [
-    getRandomNumber(37.7749, 37.7751), // longitude
-    getRandomNumber(-122.4194, -122.4196) // latitude
-  ];
+  const coordinates = [
+    getRandomNumber(-96.35119602985726, -96.33890180386302),
+    getRandomNumber(30.607255922217114, 30.617351074711575)
+  ] as Coordinates;
   const reportData = new Report({
     id: Math.floor(Math.random() * 1000),
     reportType: ReportType.MAINTENANCE,
@@ -28,7 +33,7 @@ export function createReportMockData(report = {}): Report {
       'While I was walking to the bus top to take bus 47, I noticed that there is a crack in the pavement by the bus stop. It makes it pretty easy for people to trip over it and fall.',
     reportLocation,
     reportLocationDetails,
-    geoCoordinates,
+    coordinates,
     createdAt: new Date(),
     ...report
   });

--- a/codesign/utils/report/saveReportLocal.ts
+++ b/codesign/utils/report/saveReportLocal.ts
@@ -12,7 +12,10 @@ export async function setReportsLocal(reports: Report[] = []) {
 export async function getReportsLocal(): Promise<Report[]> {
   try {
     const storedReports = await AsyncStorage.getItem('reports');
-    return JSON.parse(storedReports || '[]');
+    const rawReports = JSON.parse(storedReports || '[]');
+    // map raw reports to Report class
+    const reports = rawReports.map((report) => new Report(report));
+    return reports;
   } catch {
     console.error('Error getting reports from AsyncStorage');
     return [];

--- a/codesign/utils/report/saveReportLocal.ts
+++ b/codesign/utils/report/saveReportLocal.ts
@@ -1,0 +1,20 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Report } from '@/types/Report';
+
+export async function setReportsLocal(reports: Report[] = []) {
+  try {
+    await AsyncStorage.setItem('reports', JSON.stringify(reports));
+  } catch {
+    console.error('Error initializing reports to AsyncStorage');
+  }
+}
+
+export async function getReportsLocal(): Promise<Report[]> {
+  try {
+    const storedReports = await AsyncStorage.getItem('reports');
+    return JSON.parse(storedReports || '[]');
+  } catch {
+    console.error('Error getting reports from AsyncStorage');
+    return [];
+  }
+}


### PR DESCRIPTION
#13, #16

# Summary
Reports can be submitted now using the Report Form (tab 2). On submission, the new report will be saved locally to the phone using AsyncStorage. When closing/re-opening the app, it will fetch data from AsyncStorage to display previously submitted reports. Eventually this will be replaced by API calls to the backend.

# Details
- Create a CodesignDataProvider, which fetches data on app load
- For now, load reports from AsyncStorage, otherwise initialize some mock data and save it to AsyncStorage
- Components can access the report data using `useCodesignData` hook. This is done on the 'View Map' tab.
- Display each report on the Map using MarkerView (moved out of MapView component)
- For now, the location of each new report is randomly generated. Planning to allow the user to select location on the map next: #17 

# Demo

## Part 1
https://github.com/user-attachments/assets/19b92ce7-ed8d-40c5-85d0-0408a0674355


## Part 2

https://github.com/user-attachments/assets/c08131d5-944c-4a1e-b41f-494e0962ac75


