### PR TITLE
Swap plain text with React Component to remove warning

### DIFF
--- a/codesign/components/ui/ThemedRadioButton.tsx
+++ b/codesign/components/ui/ThemedRadioButton.tsx
@@ -1,7 +1,7 @@
 import { CheckBox } from 'react-native-elements';
 import {
   GestureResponderEvent,
-  type ViewProps,
+  type TextProps,
   StyleSheet,
   Image
 } from 'react-native';
@@ -9,9 +9,11 @@ import {
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Typography } from '@/constants/styles/Typography';
+import { ThemedText } from '../ThemedText';
+import { Spacing } from '@/constants/styles/Spacing';
 
 export type ThemedRadiobButtonProps = {
-  style?: ViewProps['style'];
+  style?: TextProps['style'];
   title: string;
   checked: boolean;
   onPress: ((event: GestureResponderEvent) => void) | undefined;
@@ -45,7 +47,14 @@ export function ThemedRadioButton({
         styles.radioButtonContainer
       ]}
       textStyle={[{ color: textColor }, { ...Typography.formText }]}
-      title={title}
+      title={
+        <ThemedText
+          type="formText"
+          style={[{ marginLeft: Spacing.small }, style]}
+        >
+          {title}
+        </ThemedText>
+      }
       checked={checked}
       onPress={onPress}
       checkedIcon={


### PR DESCRIPTION
ISSUE=#21

# Summary
A warning would show up in console whenever the Report Form rendered:

```
Warning: TextElement: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```
Fix this by passing a component into the `title` prop instead of a plain string.

## Details

Investigated the issue in the react-native-elements source code and reported the bug here: https://github.com/react-native-elements/react-native-elements/issues/3963

Checkbox throws a warning when passing a string into the title prop. Under the hood, the Checkbox checks if the title is a React component- if not, it renders the string in its own rne Text component. This Text component is throwing the warning.

The easiest workaround for this is to pass our own component into the `title` prop, so it doesn't render the faulty react-native-element Text component.

# Testing
Warning no longer shows up in console for the development build