### PR TITLE
Add required fields and form validation

### DIFF
--- a/codesign/components/ThemedText.tsx
+++ b/codesign/components/ThemedText.tsx
@@ -17,6 +17,7 @@ type ThemedTextType =
   | 'title4'
   | 'title5'
   | 'feedback'
+  | 'error'
   | 'link'
   | 'formText';
 
@@ -35,7 +36,12 @@ export function ThemedText({
   withDivider = false,
   ...rest
 }: ThemedTextProps) {
-  const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+  var defaultColor = useThemeColor(
+    { light: lightColor, dark: darkColor },
+    'text'
+  );
+  var errorColor = useThemeColor({}, 'error');
+  var textColor = type === 'error' ? errorColor : defaultColor;
 
   const typography = getTypographyByType(type);
 
@@ -44,13 +50,13 @@ export function ThemedText({
       <ThemedView
         style={[Layout.row, Layout.center, { gap: Spacing.small }, style]}
       >
-        <Text style={[{ color }, typography]} {...rest} />
+        <Text style={[{ color: textColor }, typography]} {...rest} />
         <ThemedView style={[styles.divider]} />
       </ThemedView>
     );
   }
 
-  return <Text style={[{ color }, typography, style]} {...rest} />;
+  return <Text style={[{ color: textColor }, typography, style]} {...rest} />;
 }
 
 /**

--- a/codesign/components/report/ImageUpload.tsx
+++ b/codesign/components/report/ImageUpload.tsx
@@ -136,8 +136,7 @@ export function ImageUpload({
           lightColor={tamuColors.gray700}
           darkColor={tamuColors.accentGold}
         >
-          Up to {IMAGE_UPLOAD_LIMIT} images may be uploaded. Please remove an
-          existing image to upload another.
+          Up to {IMAGE_UPLOAD_LIMIT} images may be uploaded.
         </ThemedText>
       )}
     </ThemedView>

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -85,7 +85,10 @@ export function ReportForm({ style }: ViewProps) {
     onChange: (...event: any[]) => void
   ) => {
     // reset reportLocationDetails when switching between indoor and outdoor
-    setValue('reportLocationDetails', {});
+    setValue(
+      'reportLocationDetails',
+      DefaultIndoorReport.reportLocationDetails
+    );
 
     // call onChange to update the value in the form
     onChange(reportLocation);

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -297,12 +297,7 @@ export function ReportForm({ style }: ViewProps) {
             )}
           />
         </ThemedView>
-        <ThemedView style={[styles.errorsContainer]}>
-          {Object.keys(errors).length > 0 && (
-            <ThemedText type="error" style={[Typography.textRight]}>
-              Please fill out all required fields
-            </ThemedText>
-          )}
+        <ThemedView style={[styles.errorContainer]}>
           {submissionError && (
             <ThemedText type="error" style={[Typography.textRight]}>
               {submissionError}
@@ -333,7 +328,7 @@ const styles = StyleSheet.create({
   input: {
     marginBottom: Spacing.large
   },
-  errorsContainer: {
+  errorContainer: {
     ...Layout.flex,
     ...Layout.alignEnd,
     gap: Spacing.medium,

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -203,6 +203,7 @@ export function ReportForm({ style }: ViewProps) {
                       errors.reportLocationDetails?.indoorDetails?.buildingName
                         ?.message
                     }
+                    required
                   />
                 )}
               />
@@ -223,6 +224,7 @@ export function ReportForm({ style }: ViewProps) {
                       errors.reportLocationDetails?.indoorDetails?.floorNumber
                         ?.message
                     }
+                    required
                   />
                 )}
               />
@@ -265,6 +267,7 @@ export function ReportForm({ style }: ViewProps) {
                 value={value}
                 placeholder="Enter title"
                 errorText={errors.title?.message}
+                required
               />
             )}
           />
@@ -284,6 +287,7 @@ export function ReportForm({ style }: ViewProps) {
                 multiline
                 numberOfLines={4}
                 errorText={errors.description?.message}
+                required
               />
             )}
           />

--- a/codesign/components/report/SelectLocation.tsx
+++ b/codesign/components/report/SelectLocation.tsx
@@ -110,9 +110,11 @@ export function SelectLocation({
 
   return (
     <>
-      <ThemedText type="error" style={{ marginBottom: Spacing.small }}>
-        {errorText}
-      </ThemedText>
+      {errorText && (
+        <ThemedText type="error" style={{ marginBottom: Spacing.small }}>
+          {errorText}
+        </ThemedText>
+      )}
       <LocationPreview
         onPress={openLocationModal}
         pinLocation={pinLocation}

--- a/codesign/components/report/SelectLocation.tsx
+++ b/codesign/components/report/SelectLocation.tsx
@@ -17,7 +17,6 @@ import { Coordinates } from '@/types/Report';
 import { Border } from '@/constants/styles/Border';
 import { Layout } from '@/constants/styles/Layout';
 import { ThemedText } from '@/components/ThemedText';
-import { ALBRITTON_BELL_TOWER } from '@/constants/map/Coordinates';
 import { ThemedView } from '@/components/ThemedView';
 import { MarkerView } from '@/components/map/MarkerView';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -27,6 +26,7 @@ import { ImageButton } from '@/components/ui/ImageButton';
 import { ThemedModal } from '@/components/ui/ThemedModal';
 import { TextButton } from '@/components/shared/TextButton';
 import { Typography } from '@/constants/styles/Typography';
+import { DefaultIndoorReport } from '@/constants/report/Report';
 
 const CAMERA_ZOOM = 16;
 const PREVIEW_HEIGHT = 120;
@@ -38,11 +38,13 @@ const PIN_ICON_SRC = {
 type SelectLocationProps = {
   selectedLocation: Coordinates;
   setSelectedLocation: (location: Coordinates) => void;
+  errorText?: string;
 };
 
 export function SelectLocation({
   selectedLocation,
-  setSelectedLocation
+  setSelectedLocation,
+  errorText
 }: SelectLocationProps) {
   const {
     isVisible,
@@ -66,7 +68,7 @@ export function SelectLocation({
   } else if (selectedLocation) {
     pinLocation = selectedLocation;
   } else {
-    pinLocation = ALBRITTON_BELL_TOWER;
+    pinLocation = DefaultIndoorReport.coordinates;
   }
 
   async function updateSelectedLocation() {
@@ -108,6 +110,9 @@ export function SelectLocation({
 
   return (
     <>
+      <ThemedText type="error" style={{ marginBottom: Spacing.small }}>
+        {errorText}
+      </ThemedText>
       <LocationPreview
         onPress={openLocationModal}
         pinLocation={pinLocation}

--- a/codesign/components/shared/HeaderLayout.tsx
+++ b/codesign/components/shared/HeaderLayout.tsx
@@ -7,17 +7,18 @@ import { Border } from '@/constants/styles/Border';
 import { Layout } from '@/constants/styles/Layout';
 import { Spacing } from '@/constants/styles/Spacing';
 import { ThemedScrollView } from '@/components/ThemedScrollView';
+import { tamuColors } from '@/constants/Colors';
 
 const styles = StyleSheet.create({
   parentContainer: {
     ...Layout.flex,
-    backgroundColor: 'maroon'
+    backgroundColor: tamuColors.primaryBrand
   },
   headerContainer: {
     paddingHorizontal: Spacing.large,
     paddingBottom: Spacing.large,
     paddingTop: Spacing.xxxlarge,
-    backgroundColor: 'maroon'
+    backgroundColor: tamuColors.primaryBrand
   },
   headerTitle: {
     color: 'white'

--- a/codesign/components/ui/ThemedRadioButton.tsx
+++ b/codesign/components/ui/ThemedRadioButton.tsx
@@ -76,7 +76,8 @@ export function ThemedRadioButton({
 const styles = StyleSheet.create({
   radioButtonContainer: {
     borderWidth: 0,
-    margin: 0
+    margin: 0,
+    paddingVertical: Spacing.xsmall
   },
   radioButtonText: {
     ...Typography.formText

--- a/codesign/components/ui/ThemedTextInput.tsx
+++ b/codesign/components/ui/ThemedTextInput.tsx
@@ -20,6 +20,7 @@ export type ThemedTextInputProps = TextInputProps & {
   onChangeText: ((text: string) => void) | undefined;
   value?: string | number;
   placeholder: string;
+  errorText?: string;
 };
 
 export function ThemedTextInput({
@@ -31,6 +32,7 @@ export function ThemedTextInput({
   onChangeText,
   value,
   placeholder,
+  errorText,
   ...rest
 }: ThemedTextInputProps) {
   const backgroundColor = useThemeColor({}, 'background');
@@ -40,6 +42,7 @@ export function ThemedTextInput({
   return (
     <ThemedView>
       <ThemedText type={'formText'}>{label}</ThemedText>
+      {errorText && <ThemedText type={'error'}>{errorText}</ThemedText>}
       <TextInput
         style={[
           styles.textInput,

--- a/codesign/components/ui/ThemedTextInput.tsx
+++ b/codesign/components/ui/ThemedTextInput.tsx
@@ -21,6 +21,7 @@ export type ThemedTextInputProps = TextInputProps & {
   value?: string | number;
   placeholder: string;
   errorText?: string;
+  required?: boolean;
 };
 
 export function ThemedTextInput({
@@ -33,6 +34,7 @@ export function ThemedTextInput({
   value,
   placeholder,
   errorText,
+  required,
   ...rest
 }: ThemedTextInputProps) {
   const backgroundColor = useThemeColor({}, 'background');
@@ -41,7 +43,10 @@ export function ThemedTextInput({
 
   return (
     <ThemedView>
-      <ThemedText type={'formText'}>{label}</ThemedText>
+      <ThemedText type={'formText'}>
+        {label}
+        {required && <ThemedText type="error">*</ThemedText>}
+      </ThemedText>
       {errorText && <ThemedText type={'error'}>{errorText}</ThemedText>}
       <TextInput
         style={[
@@ -55,6 +60,7 @@ export function ThemedTextInput({
         onChangeText={onChangeText}
         value={value?.toString()}
         placeholder={placeholder}
+        accessibilityLabel={required ? `${label} (required)` : label}
         {...rest}
       />
     </ThemedView>

--- a/codesign/constants/Colors.ts
+++ b/codesign/constants/Colors.ts
@@ -33,7 +33,8 @@ export const Colors = {
     tint: selectedColorLight,
     icon: tamuColors.gray500,
     tabIconDefault: tamuColors.gray500,
-    tabIconSelected: selectedColorLight
+    tabIconSelected: selectedColorLight,
+    error: '#bd1206'
   },
   dark: {
     text: '#ECEDEE',
@@ -41,6 +42,7 @@ export const Colors = {
     tint: selectedColorDark,
     icon: '#9BA1A6',
     tabIconDefault: '#9BA1A6',
-    tabIconSelected: selectedColorDark
+    tabIconSelected: selectedColorDark,
+    error: '#e34f44'
   }
 };

--- a/codesign/constants/styles/Typography.ts
+++ b/codesign/constants/styles/Typography.ts
@@ -62,6 +62,11 @@ export const Typography = {
     lineHeight: 21,
     fontFamily: 'OpenSansItalic'
   },
+  error: {
+    fontSize: 14,
+    lineHeight: 21,
+    fontFamily: 'OpenSansItalic'
+  },
   formText: {
     fontSize: 16,
     lineHeight: 24,

--- a/codesign/utils/Equality.ts
+++ b/codesign/utils/Equality.ts
@@ -1,0 +1,8 @@
+import { Coordinates } from '@/types/Report';
+
+export const areCoordinatesEqual = (
+  a: Coordinates,
+  b: Coordinates
+): boolean => {
+  return a[0] === b[0] && a[1] === b[1];
+};

--- a/codesign/utils/report/validateForm.ts
+++ b/codesign/utils/report/validateForm.ts
@@ -47,8 +47,6 @@ function validateLocationType(value: ReportLocationType) {
 }
 
 function validateCoordinates(coords: Coordinates) {
-  console.log('validate coords');
-
   const isDefaultLocation = areCoordinatesEqual(
     coords,
     DefaultIndoorReport.coordinates

--- a/codesign/utils/report/validateForm.ts
+++ b/codesign/utils/report/validateForm.ts
@@ -1,0 +1,76 @@
+import { Coordinates, ImageDetails } from '@/types/Report';
+import { IMAGE_UPLOAD_LIMIT } from '@/components/report/ImageUpload';
+import { ReportLocationType } from '@/types/Report';
+import { areCoordinatesEqual } from '../Equality';
+import { DefaultIndoorReport } from '@/constants/report/Report';
+
+export const VALIDATION_RULES = {
+  reportLocation: {
+    required: 'Floor Number is required',
+    validate: (value: ReportLocationType) => {
+      return validateLocationType(value);
+    }
+  },
+  coordinates: {
+    validate: (value: Coordinates) => {
+      return validateCoordinates(value);
+    }
+  },
+  buildingName: {
+    required: 'Building Name is required'
+  },
+  floorNumber: {
+    required: 'Floor Number is required',
+    min: { value: 1, message: 'Floor Number must be greater than 0' }
+  },
+  images: {
+    validate: (value: ImageDetails[]) => {
+      return validateImages(value);
+    }
+  },
+  title: {
+    required: 'Title is required'
+  },
+  description: {
+    required: 'Description is required'
+  }
+};
+
+function validateLocationType(value: ReportLocationType) {
+  if (
+    value !== ReportLocationType.INDOOR &&
+    value !== ReportLocationType.OUTDOOR
+  ) {
+    return 'Location must be Indoor or Outdoor';
+  }
+  return true;
+}
+
+function validateCoordinates(coords: Coordinates) {
+  console.log('validate coords');
+
+  const isDefaultLocation = areCoordinatesEqual(
+    coords,
+    DefaultIndoorReport.coordinates
+  );
+  if (!coords || isDefaultLocation) {
+    return 'Please choose location on map';
+  }
+  if (coords[0] < -180 || coords[0] > 180) {
+    return 'Longitude must be between -180 and 180';
+  }
+  if (coords[1] < -90 || coords[1] > 90) {
+    return 'Latitude must be between -90 and 90';
+  }
+  return true;
+}
+
+function validateImages(images: ImageDetails[]) {
+  if (images.length === 0) {
+    return 'At least one image is required';
+  }
+  if (images.length > IMAGE_UPLOAD_LIMIT) {
+    return `Maximum of ${IMAGE_UPLOAD_LIMIT} images can be uploaded`;
+  }
+  return true;
+}

--- a/codesign/utils/report/validateForm.ts
+++ b/codesign/utils/report/validateForm.ts
@@ -52,7 +52,7 @@ function validateCoordinates(coords: Coordinates) {
     DefaultIndoorReport.coordinates
   );
   if (!coords || isDefaultLocation) {
-    return 'Please choose location on map';
+    return 'Please choose a location on map';
   }
   if (coords[0] < -180 || coords[0] > 180) {
     return 'Longitude must be between -180 and 180';

--- a/codesign/utils/report/validateForm.ts
+++ b/codesign/utils/report/validateForm.ts
@@ -20,8 +20,9 @@ export const VALIDATION_RULES = {
     required: 'Building Name is required'
   },
   floorNumber: {
-    required: 'Floor Number is required',
-    min: { value: 1, message: 'Floor Number must be greater than 0' }
+    validate: (value: number) => {
+      return validateFloorNumber(value);
+    }
   },
   images: {
     validate: (value: ImageDetails[]) => {
@@ -42,6 +43,17 @@ function validateLocationType(value: ReportLocationType) {
     value !== ReportLocationType.OUTDOOR
   ) {
     return 'Location must be Indoor or Outdoor';
+  }
+  return true;
+}
+
+function validateFloorNumber(value: string | number) {
+  if (!value) return 'Floor Number is required'; // handle null, undefined, empty string
+  const num = typeof value === 'string' ? Number(value) : value;
+  if (isNaN(num)) return 'Floor Number must be a number';
+  if (num < 1) return 'Floor Number must be greater than 0';
+  if (!Number.isInteger(num)) {
+    return 'Floor Number must be a whole number';
   }
   return true;
 }


### PR DESCRIPTION
Resolve #26 
Resolve #24 

# Summary
Mark fields as required Add form validation- error messages appear when fields are empty, form can only be submitted when all required fields are complete

# Details

**New: Minimum one image is required now and max image size is 20MB but this may be removed if necessary**
- `ThemedTextInput` will show (*) next to label with newly added `required` prop
- Add field validation rules in util/report/validateForm.ts
- Add a new text type: error (red colored feedback text) - shade of red changes depending on light/dark mode and is [WCAG Level AAA Color Contrast compliant](https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html) 
- If API request to create report fails, show an error above the submit button


# Testing
The following flows were checked:

- required text inputs show * 
- submitting a form with empty fields shows errors
- completing field hides error, making it empty again shows error
- switching from INDOOR to OUTDOOR hides 2 fields and does not block form submission (for OUTDOOR, buildingName/floorNumber are not required in submission) 
- switching from OUTDOOR to INDOOR shows 2 fields and marks them as required if incomplete
- form may be submitted once fields are completed

## Demo Form Validation

https://github.com/user-attachments/assets/f434c4f1-e5f8-4755-8d3f-fd21a46cea08

https://github.com/user-attachments/assets/524bc7a9-a371-4897-a4c4-00e39e81fae4


## Demo error message
<!--- When fields are empty, show `Please fill out all required fields`-->
If API request to upload report to backend fails, show `An error occurred when submitting report. Please try again.`
<!--<img src="https://github.com/user-attachments/assets/67f73588-5f4d-4470-a099-bd7052c3b887" width=300 />-->
<img src="https://github.com/user-attachments/assets/f28c0266-ca24-483d-baf6-15b329dc1a56" width=300 />
