### PR TITLE
Fix form bugs

### DIFF
--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -197,8 +197,8 @@ export function ReportForm({ style }: ViewProps) {
                 render={({ field: { onChange, value } }) => (
                   <ThemedTextInput
                     label="Floor Number"
-                    value={value} // value is a number on purpose
-                    onChangeText={(text) => onChange(parseInt(text, 10) || 1)}
+                    value={value} // value may be number or string
+                    onChangeText={(text) => onChange(Number(text) || text)}
                     keyboardType="numeric"
                     placeholder="Enter floor number"
                   />

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -70,6 +70,11 @@ export function ReportForm({ style }: ViewProps) {
       });
   };
 
+  const onReset = () => {
+    // Do not change report location when resetting form
+    reset({ ...DefaultIndoorReport, reportLocation });
+  };
+
   const switchReportLocation = (
     reportLocation: ReportLocationType,
     onChange: (...event: any[]) => void
@@ -258,7 +263,7 @@ export function ReportForm({ style }: ViewProps) {
             type="tertiary"
             smallCaps={false}
             textStyle={styles.clearFormButton}
-            onPress={() => reset()}
+            onPress={onReset}
           />
           <TextButton
             text="Submit"


### PR DESCRIPTION
Resolve #28 

# Summary
- Floor number [could not be cleared](https://github.com/TAMIDS-Urban-AI-Lab/CoDesign/issues/28#issuecomment-2646634607)- it can now be fully erased
- Do not change report location (INDOOR/OUTDOOR) when resetting form

# Details
Allow the floorNumber input to have either a number or string. When the input is focused, a numeric keyboard forces the user to only input a number. If they try to "workaround it", the string will be [caught during form validation](https://github.com/TAMIDS-Urban-AI-Lab/CoDesign/pull/45/commits/27af1248f5bad9f8d6fb12e0c01bb44e3a067a81) and prevent form submission

# Testing

## Floor number can be erased

https://github.com/user-attachments/assets/eb5463db-a5f3-4e1f-bd8e-f7ce3506279c


## Keep outdoor selection when form is reset

https://github.com/user-attachments/assets/57825642-b4ab-4b54-9cf4-658448dc65ca

