### PR TITLE
Allow app to load/save reports using AsyncStorage instead of 

### DIFF
--- a/codesign/api/report/getImageById.ts
+++ b/codesign/api/report/getImageById.ts
@@ -1,11 +1,11 @@
-import { ImageDetails } from "@/types/Report";
-import axios from "axios";
-import Constants from "expo-constants";
+import { ImageDetails } from '@/types/Report';
+import axios from 'axios';
+import Constants from 'expo-constants';
 
 /**
  * Convert json response to ImageDetails type
- * @param data 
- * @returns 
+ * @param data
+ * @returns
  */
 const convertToImageDetails = (imageData: any[]): ImageDetails[] => {
   return imageData.map((item) => {
@@ -19,14 +19,14 @@ const convertToImageDetails = (imageData: any[]): ImageDetails[] => {
 /**
  * Get image by id
  * @param id: report id
- * @returns 
+ * @returns
  */
 export async function getImageById(id: number) {
   try {
     const query = `${Constants.expoConfig?.extra?.baseUrl ?? ''}/get_image?id=${id}`;
     const response = await axios.get<object>(query);
-    return convertToImageDetails(response.data["image_data"]);
-  } catch (error) {
+    return convertToImageDetails(response.data['image_data']);
+  } catch {
     return [];
   }
-};
+}

--- a/codesign/api/report/getReportByBoundary.ts
+++ b/codesign/api/report/getReportByBoundary.ts
@@ -1,17 +1,17 @@
-import axios from "axios";
-import Constants from "expo-constants";
-import { 
-  Report, 
-  ReportType, 
-  ReportLocationType, 
-  Coordinates, 
-  ReportFormDetails 
-} from "@/types/Report";
+import axios from 'axios';
+import Constants from 'expo-constants';
+import {
+  Report,
+  ReportType,
+  ReportLocationType,
+  Coordinates,
+  ReportFormDetails
+} from '@/types/Report';
 
 /**
  * Convert json response to Report type
- * @param data 
- * @returns 
+ * @param data
+ * @returns
  */
 const convertToReportArray = (data: any[]): Report[] => {
   return data.map((item) => {
@@ -19,7 +19,10 @@ const convertToReportArray = (data: any[]): Report[] => {
       id: item.id,
       createdAt: new Date(item.createAt),
       reportType: ReportType[item.reportType as keyof typeof ReportType],
-      reportLocation: ReportLocationType[item.reportLocation as keyof typeof ReportLocationType],
+      reportLocation:
+        ReportLocationType[
+          item.reportLocation as keyof typeof ReportLocationType
+        ],
       reportLocationDetails: item.reportLocationDetails || {},
       coordinates: item.coordinates as Coordinates,
       images: item.images || [],
@@ -34,15 +37,15 @@ const convertToReportArray = (data: any[]): Report[] => {
 /**
  * Get uploaded reports within boundary
  * @param west
- * @param south 
- * @param east 
- * @param north 
- * @returns 
+ * @param south
+ * @param east
+ * @param north
+ * @returns
  */
 export async function getReportByBoundary(
-  west: number, 
-  south: number, 
-  east: number, 
+  west: number,
+  south: number,
+  east: number,
   north: number
 ): Promise<Report[]> {
   try {
@@ -50,7 +53,7 @@ export async function getReportByBoundary(
     const response = await axios.get<Report[]>(query);
     const reports = convertToReportArray(response.data);
     return reports;
-  } catch (error) {
+  } catch {
     return [];
   }
-};
+}

--- a/codesign/api/report/getReportByBoundary.ts
+++ b/codesign/api/report/getReportByBoundary.ts
@@ -7,6 +7,11 @@ import {
   Coordinates,
   ReportFormDetails
 } from '@/types/Report';
+import { createReportMockData } from '@/utils/report/createReportMockData';
+import {
+  getReportsLocal,
+  setReportsLocal
+} from '@/utils/report/saveReportLocal';
 
 /**
  * Convert json response to Report type
@@ -55,5 +60,32 @@ export async function getReportByBoundary(
     return reports;
   } catch {
     return [];
+  }
+}
+
+export async function getReportByBoundaryLocal(
+  west: number,
+  south: number,
+  east: number,
+  north: number
+): Promise<Report[]> {
+  try {
+    const reports = await getReportsLocal();
+    if (reports.length === 0) {
+      throw new Error('No reports so initializing with mock data');
+    }
+    return reports;
+  } catch {
+    const mockData = [
+      createReportMockData(),
+      createReportMockData(),
+      createReportMockData()
+    ];
+    try {
+      setReportsLocal(mockData);
+      return mockData;
+    } catch {
+      throw new Error('Error initializing reports to AsyncStorage');
+    }
   }
 }

--- a/codesign/api/report/uploadReport.ts
+++ b/codesign/api/report/uploadReport.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
 import Constants from 'expo-constants';
-import { ReportFormDetails } from '@/types/Report';
+
+import { ReportFormDetails, Report } from '@/types/Report';
+import {
+  getReportsLocal,
+  setReportsLocal
+} from '@/utils/report/saveReportLocal';
 
 /**
  * Upload report to the server
@@ -8,6 +13,12 @@ import { ReportFormDetails } from '@/types/Report';
  */
 export async function uploadReport(reportData: ReportFormDetails) {
   try {
+    if (Constants.expoConfig?.extra?.testWithoutBackend) {
+      const newReport = new Report(reportData);
+      const reports = await getReportsLocal();
+      setReportsLocal([...reports, newReport]);
+      return { id: Math.floor(Math.random() * 1000) };
+    }
     const query = `${Constants.expoConfig?.extra?.baseUrl ?? ''}/locations`;
     const response = await axios.post(query, JSON.stringify([reportData]), {
       headers: {

--- a/codesign/api/report/uploadReport.ts
+++ b/codesign/api/report/uploadReport.ts
@@ -1,21 +1,21 @@
-import axios from "axios";
-import Constants from "expo-constants";
-import { ReportFormDetails } from "@/types/Report";
+import axios from 'axios';
+import Constants from 'expo-constants';
+import { ReportFormDetails } from '@/types/Report';
 
 /**
  * Upload report to the server
- * @param reports 
+ * @param reports
  */
 export async function uploadReport(reportData: ReportFormDetails) {
   try {
     const query = `${Constants.expoConfig?.extra?.baseUrl ?? ''}/locations`;
     const response = await axios.post(query, JSON.stringify([reportData]), {
       headers: {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json'
       }
     });
     return response.data;
-  } catch (error) {
-    throw new Error("Server-error: POST");
+  } catch {
+    throw new Error('Server-error: POST');
   }
-};
+}

--- a/codesign/app.config.ts
+++ b/codesign/app.config.ts
@@ -7,6 +7,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   slug: 'codesign',
   extra: {
     mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN,
-    baseUrl: process.env.BASE_URL
+    baseUrl: process.env.BASE_URL,
+    // set NO_BACKEND=true to test without backend
+    testWithoutBackend: process.env.NO_BACKEND
   }
 });

--- a/codesign/app/(tabs)/index.tsx
+++ b/codesign/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Image } from 'react-native';
 import { Camera } from '@rnmapbox/maps';
 import { useState } from 'react';
+import Constants from 'expo-constants';
 
 import { ThemedView } from '@/components/ThemedView';
 import { MapView } from '@/components/map/MapView';
@@ -53,11 +54,18 @@ export default function HomeScreen() {
 
     if (displayedReport?.getId() !== report.getId()) {
       // retrieve images from the server by id
-      getImageById(report.getId()).then((data) => {
-        report.images = data;
-        rerenderSheet((prev) => prev + 1);
-        setDisplayedReport(report);
-      });
+      if (!Constants.expoConfig?.extra?.testWithoutBackend) {
+        getImageById(report.getId())
+          .then((data) => {
+            report.images = data;
+          })
+          .catch(() => {
+            // TO DO: Handle image fetching error
+          });
+      }
+
+      rerenderSheet((prev) => prev + 1);
+      setDisplayedReport(report);
     }
   };
 

--- a/codesign/components/provider/CodesignDataProvider.tsx
+++ b/codesign/components/provider/CodesignDataProvider.tsx
@@ -32,24 +32,28 @@ export const CodesignDataProvider = ({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // selected location 
+    // selected location
     // TODO: make this dynamically get bbox based on screen size
     const loc = {
-    west: -96.339152,
-    south: 30.600238,
-    east: -96.334904,
-    north: 30.627126,
+      west: -96.339152,
+      south: 30.600238,
+      east: -96.334904,
+      north: 30.627126
     };
-    
+
     getReportByBoundary(loc.west, loc.south, loc.east, loc.north)
-    .then((reports: Report[]) => {
-      if (reports.length == 0) {
-        throw new Error("No reports found at this location");
-      }
-      setReports(reports);
-      setIsLoading(false);
-    });
-  },[]);
+      .then((reports: Report[]) => {
+        if (reports.length === 0) {
+          throw new Error('No reports found at this location');
+        }
+        setReports(reports);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setIsLoading(false);
+      });
+  }, []);
 
   return (
     <CodesignDataContext.Provider

--- a/codesign/components/provider/CodesignDataProvider.tsx
+++ b/codesign/components/provider/CodesignDataProvider.tsx
@@ -1,6 +1,11 @@
 import { createContext, useContext, useEffect, useState } from 'react';
+import Constants from 'expo-constants';
+
 import { Report } from '@/types/Report';
-import { getReportByBoundary } from '@/api/report/getReportByBoundary';
+import {
+  getReportByBoundary,
+  getReportByBoundaryLocal
+} from '@/api/report/getReportByBoundary';
 
 type CodesignDataContextType = {
   reports: Report[];
@@ -41,7 +46,11 @@ export const CodesignDataProvider = ({
       north: 30.627126
     };
 
-    getReportByBoundary(loc.west, loc.south, loc.east, loc.north)
+    const noBackend = Constants.expoConfig?.extra?.testWithoutBackend;
+
+    const getData = noBackend ? getReportByBoundaryLocal : getReportByBoundary;
+
+    getData(loc.west, loc.south, loc.east, loc.north)
       .then((reports: Report[]) => {
         if (reports.length === 0) {
           throw new Error('No reports found at this location');
@@ -49,7 +58,7 @@ export const CodesignDataProvider = ({
         setReports(reports);
         setIsLoading(false);
       })
-      .catch((err) => {
+      .catch((err: Error) => {
         setError(err.message);
         setIsLoading(false);
       });

--- a/codesign/components/report/ReportDetailsSheet.tsx
+++ b/codesign/components/report/ReportDetailsSheet.tsx
@@ -167,10 +167,10 @@ function ReportDetails({ report }: { report: Report }) {
 
 const getImageSrc = (images: ImageDetails[]) => {
   if (!images || images.length === 0) return DEFAULT_IMAGE_SRC;
-  if (typeof images[0].uri === "string") {
+  if (typeof images[0].uri === 'string') {
     return { uri: images[0].uri };
-  } else if (typeof images[0].base64 === "string") {
-    return { uri: "data:image/png;base64," + images[0].base64 }
+  } else if (typeof images[0].base64 === 'string') {
+    return { uri: 'data:image/png;base64,' + images[0].base64 };
   } else {
     return images[0].uri;
   }

--- a/codesign/hooks/report/createReport.ts
+++ b/codesign/hooks/report/createReport.ts
@@ -1,4 +1,3 @@
-import { uploadReport } from '@/api/report/uploadReport';
 import { ReportFormDetails } from '@/types/Report';
 
 async function createReport(data: ReportFormDetails) {
@@ -6,7 +5,6 @@ async function createReport(data: ReportFormDetails) {
     // This is where you would make a request to your API to create the report
     // Backend returns an id associated with the report
     const id = Math.floor(Math.random() * 1000);
-    const response = await uploadReport(data);
     return { id };
   } catch {
     throw new Error('Failed to create report');

--- a/codesign/package-lock.json
+++ b/codesign/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/bottom-tabs": "^7.0.0",
         "@react-navigation/native": "^7.0.0",
         "@rnmapbox/maps": "^10.1.33",
+        "axios": "^1.7.9",
         "date-fns": "^4.1.0",
         "expo": "~52.0.20",
         "expo-blur": "~14.0.1",
@@ -5685,6 +5686,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -9102,6 +9128,26 @@
       "integrity": "sha512-7QHV2m2mIMh6yIMaAPOVbyNEW77IARwO69d4DgvfDCjuORiykdMLf7XBjF7Zeov7Cpe1OXJ8sB6/aaCE3xuRBw==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -14423,6 +14469,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",


### PR DESCRIPTION
# Summary
If user is testing without local/production backend, allow frontend to still work.

This is a stop-gap solution for the demo tomorrow, and will not be merged into master.

The longterm solution to get app working without Dev backend is using a Mirage server, which I will add next.

# Instructions
```
// Check out this code
git checkout origin/mkodial/add-nondev-support

// Clear cache 
npm run clean-ios

// Set flag to run without dev backend
NO_BACKEND=true npm run ios

```