### PR TITLE
Allow camera access in Codesign

### DIFF
--- a/codesign/app/_layout.tsx
+++ b/codesign/app/_layout.tsx
@@ -11,6 +11,7 @@ import { useEffect } from 'react';
 import 'react-native-reanimated';
 import MapboxGL from '@rnmapbox/maps';
 import Constants from 'expo-constants';
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useFonts } from '@/hooks/useFonts';
@@ -49,7 +50,9 @@ function App({ children }: { children: React.ReactNode }) {
         <ThemeProvider
           value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
         >
-          <ModalProvider>{children}</ModalProvider>
+          <ActionSheetProvider>
+            <ModalProvider>{children}</ModalProvider>
+          </ActionSheetProvider>
         </ThemeProvider>
       </CodesignDataProvider>
     </GestureHandlerRootView>

--- a/codesign/components/report/ImageUpload.tsx
+++ b/codesign/components/report/ImageUpload.tsx
@@ -15,6 +15,7 @@ import {
   ImagePickerOptions
 } from 'expo-image-picker';
 import { useActionSheet } from '@expo/react-native-action-sheet';
+import { saveToLibraryAsync } from 'expo-media-library';
 
 import { ThemedView } from '@/components/ThemedView';
 import { TextButton } from '@/components/shared/TextButton';
@@ -123,6 +124,7 @@ export function ImageUpload({
           const newImages = addSelectedImage(result.assets[0]);
           updateForm(newImages);
           setUploadErrorText(null);
+          saveToLibraryAsync(result.assets[0].uri);
         } else if (result?.canceled) {
           setUploadErrorText(null);
         } else {

--- a/codesign/package-lock.json
+++ b/codesign/package-lock.json
@@ -23,6 +23,7 @@
         "expo-dev-client": "~5.0.8",
         "expo-font": "~13.0.2",
         "expo-haptics": "~14.0.0",
+        "expo-image-manipulator": "~13.0.6",
         "expo-image-picker": "~16.0.3",
         "expo-linking": "~7.0.3",
         "expo-location": "~18.0.5",
@@ -8560,6 +8561,18 @@
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
       "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.0.6.tgz",
+      "integrity": "sha512-Rz8Kcfx1xYm0AsIDi6zfKYUDnwCP8edgYXWb00KAkzOF8bDxwzTrnvESWhCiveM4IB3fojjLpNeENME34p3bzA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/codesign/package-lock.json
+++ b/codesign/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/bottom-tabs": "^7.0.0",
         "@react-navigation/native": "^7.0.0",
         "@rnmapbox/maps": "^10.1.33",
+        "axios": "^1.7.9",
         "date-fns": "^4.1.0",
         "expo": "~52.0.20",
         "expo-blur": "~14.0.1",
@@ -25,6 +26,7 @@
         "expo-image-picker": "~16.0.3",
         "expo-linking": "~7.0.3",
         "expo-location": "~18.0.5",
+        "expo-media-library": "~17.0.6",
         "expo-router": "~4.0.15",
         "expo-splash-screen": "~0.29.18",
         "expo-status-bar": "~2.0.0",
@@ -5685,6 +5687,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -7493,15 +7521,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8598,6 +8626,16 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-media-library": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-17.0.6.tgz",
+      "integrity": "sha512-LUnfrddmee1xLOkyG2NN1l9xQbtvMX3fbM1brEGHg0SKSndvjod3FQdhTzZEYAariqW2RSxQR8v1IsheIoLQXg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.0.4.tgz",
@@ -9102,6 +9140,26 @@
       "integrity": "sha512-7QHV2m2mIMh6yIMaAPOVbyNEW77IARwO69d4DgvfDCjuORiykdMLf7XBjF7Zeov7Cpe1OXJ8sB6/aaCE3xuRBw==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -14423,6 +14481,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/codesign/package.json
+++ b/codesign/package.json
@@ -59,7 +59,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
-    "react-refresh": "^0.16.0"
+    "react-refresh": "^0.16.0",
+    "expo-media-library": "~17.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/codesign/package.json
+++ b/codesign/package.json
@@ -39,9 +39,11 @@
     "expo-dev-client": "~5.0.8",
     "expo-font": "~13.0.2",
     "expo-haptics": "~14.0.0",
+    "expo-image-manipulator": "~13.0.6",
     "expo-image-picker": "~16.0.3",
     "expo-linking": "~7.0.3",
     "expo-location": "~18.0.5",
+    "expo-media-library": "~17.0.6",
     "expo-router": "~4.0.15",
     "expo-splash-screen": "~0.29.18",
     "expo-status-bar": "~2.0.0",
@@ -59,8 +61,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
-    "react-refresh": "^0.16.0",
-    "expo-media-library": "~17.0.6"
+    "react-refresh": "^0.16.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Resolve #49

# Summary 
Reporters can access camera in Codesign to take and upload photos. When large images are added, reduce the size + compress. Impact: This reduces the image's file size to 20-40% of the original size while maintaining reasonable quality.

# Details
- Use iOS native Action Sheet to present 2 options: Use Camera, Upload from Photo Library
- Photos taken with camera will be automatically saved to reporter's photo library. 
- All uploaded photos will now be resized to roughly 1080p and compressed - Resolve #55

# Testing


## Upload with Camera

https://github.com/user-attachments/assets/460bcb0e-6078-48c3-ad43-6265ca7cffd1

## Submit form with camera uploads


https://github.com/user-attachments/assets/94c66a4f-fb7e-4284-9357-3bb4c5dd8d03


## Upload from Photo Library 

https://github.com/user-attachments/assets/2e170707-b4eb-48da-866f-8d6ea1e920e3


