### PR TITLE
Test image upload flow

### DIFF
--- a/codesign/components/__tests__/report/ImageUpload-test.tsx
+++ b/codesign/components/__tests__/report/ImageUpload-test.tsx
@@ -1,0 +1,196 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor
+} from '@testing-library/react-native';
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
+
+import {
+  ActionSheetCallback,
+  ActionSheetOptions,
+  mockActionSheet
+} from '@/mocks/mockActionSheet';
+import { mockExpoImagePicker } from '@/mocks/mockExpoImagePicker';
+import { mockExpoImageManipulator } from '@/mocks/mockExpoImageManipulator';
+import { mockExpoMediaLibrary } from '@/mocks/mockExpoMediaLibrary';
+
+describe('<ImageUpload />', () => {
+  // Set up action sheet mocks
+  const { mockShowActionSheetWithOptions } = mockActionSheet();
+  const expectedMenuOptions = {
+    useCamera: 0,
+    uploadFromLibrary: 1,
+    cancel: 2
+  };
+
+  // Set up mocks for camera and media library access
+  const mockedImageSize = {
+    mockWidth: 1920,
+    mockHeight: 1080
+  };
+  const {
+    mockLaunchCameraAsync,
+    mockLaunchImageLibraryAsync,
+    mockMediaLibraryPermissions,
+    mockCameraPermissions,
+    grantPermission
+  } = mockExpoImagePicker(mockedImageSize);
+  mockCameraPermissions.mockImplementation(grantPermission);
+  mockMediaLibraryPermissions.mockImplementation(grantPermission);
+
+  // Set up mocks to resize and compress images
+  const { mockResize } = mockExpoImageManipulator(mockedImageSize);
+
+  // Set up mocks for saving images to the library
+  const { mockSaveToLibraryAsync } = mockExpoMediaLibrary();
+
+  // Now import the component after the mocks are set up
+  const { ImageUpload } = require('@/components/report/ImageUpload');
+  const initComponent = (props: any) => (
+    <ActionSheetProvider>
+      <ImageUpload
+        onChange={props.onChange}
+        value={props.value}
+        errorText={props.errorText}
+      />
+    </ActionSheetProvider>
+  );
+
+  beforeEach(() => {
+    mockShowActionSheetWithOptions.mockClear();
+    mockLaunchCameraAsync.mockClear();
+    mockLaunchImageLibraryAsync.mockClear();
+    mockCameraPermissions.mockClear();
+    mockMediaLibraryPermissions.mockClear();
+    mockResize.mockClear();
+    mockSaveToLibraryAsync.mockClear();
+  });
+
+  test('renders the preview row and "Add Photos" button', async () => {
+    // When view the Image Upload component
+    render(initComponent({ onChange: jest.fn(), value: [], errorText: null }));
+
+    // show preview row
+    expect(screen.getByTestId('image-upload-preview-row')).toBeVisible();
+
+    // and show the "Add Photos" button
+    const addPhotosButton = await screen.findByText('Add Photos');
+    expect(addPhotosButton).toBeVisible();
+
+    // When click on the "Add Photos" button
+    fireEvent.press(addPhotosButton);
+
+    // Then show the options menu
+    expect(mockShowActionSheetWithOptions).toHaveBeenCalled();
+
+    // and correct options are provided
+    const actionSheetConfig: ActionSheetOptions = mockShowActionSheetWithOptions
+      .mock.calls[0][0] as unknown as ActionSheetOptions;
+    expect(actionSheetConfig.options).toEqual([
+      'Use Camera',
+      'Upload from Library',
+      'Cancel'
+    ]);
+
+    // When select the "Cancel" option
+    const actionSheetCallback: ActionSheetCallback =
+      mockShowActionSheetWithOptions.mock
+        .calls[0][1] as unknown as ActionSheetCallback;
+    actionSheetCallback(expectedMenuOptions.cancel);
+
+    // Then the options menu is closed
+    expect(mockShowActionSheetWithOptions).toHaveBeenCalledTimes(1);
+    expect(mockLaunchCameraAsync).not.toHaveBeenCalled();
+    expect(mockResize).not.toHaveBeenCalled();
+  });
+
+  test('opens the camera when selecting Use Camera option', async () => {
+    // When view the Image Upload component
+    const mockUpdateForm = jest.fn();
+    render(
+      initComponent({
+        onChange: mockUpdateForm,
+        value: [],
+        errorText: null
+      })
+    );
+
+    // When click on the "Add Photos" button
+    const addPhotosButton = await screen.findByText('Add Photos');
+    fireEvent.press(addPhotosButton);
+
+    // When select the "Use Camera" option
+    const actionSheetCallback: ActionSheetCallback =
+      mockShowActionSheetWithOptions.mock
+        .calls[0][1] as unknown as ActionSheetCallback;
+    actionSheetCallback(expectedMenuOptions.useCamera);
+
+    // Then show the camera to the user
+    await waitFor(() => {
+      expect(mockLaunchCameraAsync).toHaveBeenCalledTimes(1);
+    });
+
+    // After photo is taken, the image is resized
+    await waitFor(() => {
+      expect(mockResize).toHaveBeenCalledTimes(1);
+    });
+
+    // and added to the form
+    await waitFor(() => {
+      expect(mockUpdateForm).toHaveBeenCalledTimes(1);
+    });
+
+    // and saved to the library
+    await waitFor(() => {
+      expect(mockSaveToLibraryAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('opens the photo library when selecting Upload from Library option', async () => {
+    // When view the Image Upload component
+    const mockUpdateForm = jest.fn();
+    render(
+      initComponent({ onChange: mockUpdateForm, value: [], errorText: null })
+    );
+
+    // When click on the "Add Photos" button
+    const addPhotosButton = await screen.findByText('Add Photos');
+    fireEvent.press(addPhotosButton);
+
+    // When select the "Upload from Library" option
+    const actionSheetCallback: ActionSheetCallback =
+      mockShowActionSheetWithOptions.mock
+        .calls[0][1] as unknown as ActionSheetCallback;
+    actionSheetCallback(expectedMenuOptions.uploadFromLibrary);
+
+    // Then show the camera to the user
+    await waitFor(() => {
+      expect(mockLaunchImageLibraryAsync).toHaveBeenCalledTimes(1);
+    });
+
+    // After image is selected from library, the image is resized
+    await waitFor(() => {
+      expect(mockResize).toHaveBeenCalledTimes(1);
+    });
+
+    // and added to the form
+    await waitFor(() => {
+      expect(mockUpdateForm).toHaveBeenCalledTimes(1);
+    });
+
+    // and it should not be saved to the library (because it was selected from the library)
+    await waitFor(() => {
+      expect(mockSaveToLibraryAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  test('renders error text from the form', () => {
+    // When view the Image Upload component
+    const errorText = 'Form is missing an image';
+    render(initComponent({ onChange: jest.fn(), value: [], errorText }));
+
+    // Then show the error text above the preview row
+    expect(screen.getByText(errorText)).toBeVisible();
+  });
+});

--- a/codesign/components/report/ImageUpload.tsx
+++ b/codesign/components/report/ImageUpload.tsx
@@ -51,8 +51,8 @@ export function ImageUpload({
   value: images,
   errorText
 }: ImageUploadProps) {
-  const [libraryStatus, requestLibraryPermission] =
-    useMediaLibraryPermissions();
+  const testData = useMediaLibraryPermissions();
+  const [libraryStatus, requestLibraryPermission] = testData;
   const [cameraStatus, requestCameraPermission] = useCameraPermissions();
   const [uploadErrorText, setUploadErrorText] = useState<string | null>(null);
   const { showActionSheetWithOptions } = useActionSheet();
@@ -69,14 +69,14 @@ export function ImageUpload({
     image: ImagePickerAsset
   ): Promise<ImagePickerAsset> => {
     if (image.width <= MAX_RESOLUTION) {
-      return image;
+      return Promise.resolve(image);
     }
     try {
-      const resized = await ImageManipulator.manipulate(image.uri)
-        .resize({ width: MAX_RESOLUTION })
-        .renderAsync();
+      const manipulated = ImageManipulator.manipulate(image.uri);
+      const resized = manipulated.resize({ width: MAX_RESOLUTION });
+      const rendered = await resized.renderAsync();
 
-      const newImage = await resized.saveAsync({
+      const newImage = await rendered.saveAsync({
         format: SaveFormat.JPEG,
         compress: 0.5,
         base64: true
@@ -229,10 +229,18 @@ export function ImageUpload({
           {uploadErrorText}
         </ThemedText>
       )}
-      <ThemedView style={styles.imagePreviewRow} key="image_previews">
+      <ThemedView
+        style={styles.imagePreviewRow}
+        key="image_previews"
+        testID="image-upload-preview-row"
+      >
         {images.map((image, index) => {
           return (
-            <ThemedView key={`uploaded_${index}`} style={styles.imageContainer}>
+            <ThemedView
+              key={`uploaded_${index}`}
+              style={styles.imageContainer}
+              testID="user-submitted-image-upload"
+            >
               <ImageButton
                 source={REMOVE_IMAGE_SRC}
                 size={24}
@@ -253,6 +261,7 @@ export function ImageUpload({
           type="secondary"
           text="Add Photos"
           onPress={showOptionsMenu}
+          testID="image-upload-add-photos"
         />
       )}
       {maxImagesUploaded && (
@@ -274,6 +283,7 @@ function DefaultImage() {
       lightColor={tamuColors.gray300}
       darkColor={tamuColors.gray800}
       style={styles.defaultContainer}
+      testID="image-upload-default-preview"
     >
       <IconSymbol name="photo.fill" size={28} color={tamuColors.gray500} />
     </ThemedView>

--- a/codesign/components/report/ImageUpload.tsx
+++ b/codesign/components/report/ImageUpload.tsx
@@ -229,11 +229,7 @@ export function ImageUpload({
           {uploadErrorText}
         </ThemedText>
       )}
-      <ThemedView
-        style={styles.imagePreviewRow}
-        key="image_previews"
-        testID="image-upload-preview-row"
-      >
+      <ThemedView style={styles.imagePreviewRow} key="image_previews">
         {images.map((image, index) => {
           return (
             <ThemedView

--- a/codesign/mocks/mockActionSheet.tsx
+++ b/codesign/mocks/mockActionSheet.tsx
@@ -1,0 +1,27 @@
+export type ActionSheetOptions = {
+  options?: string[];
+  cancelButtonIndex?: number;
+  title?: string;
+};
+
+export type ActionSheetCallback = (buttonIndex: number) => void;
+
+export function mockActionSheet() {
+  const mockActionSheet = jest.fn(
+    () => (_options: ActionSheetOptions, _callback: ActionSheetCallback) => {
+      _callback(0);
+    }
+  );
+  jest.mock('@expo/react-native-action-sheet', () => {
+    return {
+      __esModule: true,
+      ...jest.requireActual('@expo/react-native-action-sheet'),
+      useActionSheet: () => ({
+        showActionSheetWithOptions: mockActionSheet
+      })
+    };
+  });
+  return {
+    mockShowActionSheetWithOptions: mockActionSheet
+  };
+}

--- a/codesign/mocks/mockExpoImageManipulator.tsx
+++ b/codesign/mocks/mockExpoImageManipulator.tsx
@@ -1,0 +1,62 @@
+export function mockExpoImageManipulator({
+  mockWidth,
+  mockHeight
+}: {
+  mockWidth: number;
+  mockHeight: number;
+}) {
+  type ImageResult = {
+    uri: string;
+    width: number;
+    height: number;
+    base64?: string;
+  };
+  type ImageRef = {
+    width: number;
+    height: number;
+    saveAsync(options?: any): Promise<ImageResult>;
+  };
+  const mockResize = jest.fn();
+  const mockSaveAsync = jest.fn(() => {
+    return Promise.resolve({
+      uri: 'file://path/to/image.jpg',
+      width: mockWidth,
+      height: mockHeight,
+      base64: 'base64string'
+    } as ImageResult);
+  });
+  const mockImageContext = jest.fn(() => {
+    return {
+      resize: mockResize.mockImplementation(() => mockImageContext()),
+      renderAsync: () => mockRenderAsync(mockSaveAsync)
+    };
+  });
+
+  const mockRenderAsync = jest.fn((mockSaveAsync) =>
+    Promise.resolve({
+      width: mockWidth,
+      height: mockHeight,
+      saveAsync: mockSaveAsync
+    } as ImageRef)
+  );
+
+  jest.mock('expo-image-manipulator', () => {
+    return {
+      __esModule: true,
+      ImageManipulator: {
+        manipulate: mockImageContext
+      },
+      SaveFormat: {
+        JPEG: 'jpeg',
+        PNG: 'png',
+        WEBP: 'webp'
+      }
+    };
+  });
+
+  return {
+    mockResize,
+    mockSaveAsync,
+    mockRenderAsync
+  };
+}

--- a/codesign/mocks/mockExpoImagePicker.tsx
+++ b/codesign/mocks/mockExpoImagePicker.tsx
@@ -16,7 +16,7 @@ export function mockExpoImagePicker({
   ];
 
   type ImagePickerResult = {
-    canceled: false;
+    canceled: boolean;
     assets: ImagePickerAsset[];
   };
 

--- a/codesign/mocks/mockExpoImagePicker.tsx
+++ b/codesign/mocks/mockExpoImagePicker.tsx
@@ -1,0 +1,77 @@
+export function mockExpoImagePicker({
+  mockWidth,
+  mockHeight
+}: {
+  mockWidth: number;
+  mockHeight: number;
+}) {
+  const grantPermission = () => [
+    { status: 'granted' },
+    jest.fn(() => Promise.resolve({ status: 'granted' }))
+  ];
+
+  const denyPermission = () => [
+    { status: 'denied' },
+    jest.fn(() => Promise.resolve({ status: 'denied' }))
+  ];
+
+  type ImagePickerResult = {
+    canceled: false;
+    assets: ImagePickerAsset[];
+  };
+
+  type ImagePickerAsset = any;
+
+  const mockMediaLibraryPermissions = jest.fn(grantPermission);
+  const mockCameraPermissions = jest.fn();
+  const mockLaunchImageLibraryAsync = jest.fn(() => {
+    const response: ImagePickerResult = {
+      assets: [
+        {
+          uri: 'file://path/to/image.jpg',
+          width: mockWidth,
+          height: mockHeight,
+          fileName: 'image.jpg',
+          type: 'image/jpeg'
+        }
+      ],
+      canceled: false
+    };
+    return Promise.resolve(response);
+  });
+
+  const mockLaunchCameraAsync = jest.fn(() => {
+    const response: ImagePickerResult = {
+      assets: [
+        {
+          uri: 'file://path/to/image.jpg',
+          width: mockWidth,
+          height: mockHeight,
+          fileName: 'image.jpg',
+          type: 'image/jpeg'
+        }
+      ],
+      canceled: false
+    };
+    return Promise.resolve(response);
+  });
+
+  jest.mock('expo-image-picker', () => {
+    return {
+      __esModule: true,
+      useMediaLibraryPermissions: mockMediaLibraryPermissions,
+      useCameraPermissions: mockCameraPermissions,
+      launchImageLibraryAsync: mockLaunchImageLibraryAsync,
+      launchCameraAsync: mockLaunchCameraAsync
+    };
+  });
+
+  return {
+    grantPermission,
+    denyPermission,
+    mockMediaLibraryPermissions,
+    mockCameraPermissions,
+    mockLaunchImageLibraryAsync,
+    mockLaunchCameraAsync
+  };
+}

--- a/codesign/mocks/mockExpoMediaLibrary.tsx
+++ b/codesign/mocks/mockExpoMediaLibrary.tsx
@@ -1,0 +1,14 @@
+export function mockExpoMediaLibrary() {
+  const mockSaveToLibraryAsync = jest.fn(() => Promise.resolve());
+
+  jest.mock('expo-media-library', () => {
+    return {
+      __esModule: true,
+      saveToLibraryAsync: mockSaveToLibraryAsync
+    };
+  });
+
+  return {
+    mockSaveToLibraryAsync
+  };
+}


### PR DESCRIPTION
#67 
# Summary
When someone is creating a report, they may upload up to 3 images from either photo library or take directly from their camera. Add tests for this flow.

# Details
- Mock out the following 3rd party libraries to return mock data: 
    - expo-image-manipulator
    - expo-image-picker
    - expo-media-library
    - @expo/react-native-action-sheet
When testing components that rely on these third party libraries, mock them out to return mocked data.

Test the following scenarios:
- Image Upload component shows 3 default images and an "Add Photos" button
- Correct options show up in action sheet: Use Camera, Upload from Library, Cancel
- Can select 'Use Camera' option to upload an image
- Can select 'Upload from Library' option to upload an image
- When form has errors, the Image Upload component will show the error text
- When images are added, the Image Upload component will show the images
- When adding an image fails, the Image Upload component will let the user know with error text as feedback

# Testing
Tests pass
Build succeeds, no runtime errors
