### PR TITLE
Add tests for provider components

### DIFF
--- a/codesign/api/__tests__/report/getImageById-test.tsx
+++ b/codesign/api/__tests__/report/getImageById-test.tsx
@@ -47,12 +47,12 @@ describe('getImageById', () => {
   });
   describe('when the fetch fails', () => {
     beforeAll(() => {
-      global.fetch = mockFetchError('Fetching image failed');
+      global.fetch = mockFetchError('Backend error message');
     });
     afterAll(() => {
       jest.resetAllMocks();
     });
-    test('should throw an error', async () => {
+    test('should throw the correct error message', async () => {
       await expect(getImageById(testId)).rejects.toThrow(
         'An error occurred while fetching the image.'
       );

--- a/codesign/api/__tests__/report/getReportByBoundary-test.ts
+++ b/codesign/api/__tests__/report/getReportByBoundary-test.ts
@@ -67,12 +67,12 @@ describe('getReportByBoundary', () => {
   });
   describe('when the fetch fails', () => {
     beforeEach(() => {
-      global.fetch = mockFetchError();
+      global.fetch = mockFetchError('Backend error message');
     });
     afterEach(() => {
       jest.resetAllMocks();
     });
-    test('should throw an error', async () => {
+    test('should throw the correct error message', async () => {
       await expect(
         getReportByBoundary(
           testProps.west,

--- a/codesign/api/__tests__/report/uploadReport-test.tsx
+++ b/codesign/api/__tests__/report/uploadReport-test.tsx
@@ -45,13 +45,13 @@ describe('uploadReport', () => {
 
   describe('when the fetch fails', () => {
     beforeAll(() => {
-      global.fetch = mockFetchError('Failed to upload report');
+      global.fetch = mockFetchError('Backend error message');
     });
     afterAll(() => {
       jest.resetAllMocks();
     });
 
-    test('should throw an error', async () => {
+    test('should throw the correct error message', async () => {
       await expect(uploadReport(testReportData)).rejects.toThrow(
         'An error occurred while uploading the report.'
       );

--- a/codesign/components/__tests__/provider/CodesignDataProvider-test.tsx
+++ b/codesign/components/__tests__/provider/CodesignDataProvider-test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react-native';
+import { Text, View } from 'react-native';
+
+import {
+  CodesignDataProvider,
+  useCodesignData,
+  CodesignDataContextType
+} from '@/components/provider/CodesignDataProvider';
+import { createMockedReportFormDetails } from '@/mocks/mockReport';
+import { ReportFormDetails, Report } from '@/types/Report';
+import { ApiResponse } from '@/types/api';
+import { mockFetchSuccess, mockFetchError } from '@/mocks/mockFetch';
+
+const TestingComponent = () => {
+  const { reports, error }: CodesignDataContextType = useCodesignData();
+  return (
+    <View>
+      <Text>Child Component</Text>
+      {reports.length && <Text>{JSON.stringify(reports)}</Text>}
+      {error && <Text>{error}</Text>}
+    </View>
+  );
+};
+
+describe('<CodesignDataProvider />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when fetching report data succeeds', () => {
+    test('it provides report data', async () => {
+      const reportData: ReportFormDetails[] = [
+        createMockedReportFormDetails({ id: 111 }),
+        createMockedReportFormDetails({ id: 222 }),
+        createMockedReportFormDetails({ id: 333 })
+      ];
+      const successResponse: ApiResponse<ReportFormDetails[]> = {
+        status: 200,
+        message: 'Success',
+        data: reportData
+      };
+      global.fetch = mockFetchSuccess(successResponse);
+
+      render(
+        <CodesignDataProvider>
+          <TestingComponent />
+        </CodesignDataProvider>
+      );
+
+      const expectedReports = JSON.stringify(
+        reportData.map((item) => new Report(item))
+      );
+
+      const childComponent = await screen.findByText('Child Component');
+      const reports = await screen.findByText(expectedReports);
+
+      expect(childComponent).toBeVisible();
+      expect(reports).toBeVisible();
+    });
+  });
+
+  describe('when fetching report data fails', () => {
+    test('it provides an error', async () => {
+      global.fetch = mockFetchError();
+      render(
+        <CodesignDataProvider>
+          <TestingComponent />
+        </CodesignDataProvider>
+      );
+
+      const childComponent = await screen.findByText('Child Component');
+      const errorText = await screen.findByText(
+        'An error occurred while fetching reports.'
+      );
+
+      expect(childComponent).toBeVisible();
+      expect(errorText).toBeVisible();
+    });
+  });
+});

--- a/codesign/components/__tests__/provider/CodesignDataProvider-test.tsx
+++ b/codesign/components/__tests__/provider/CodesignDataProvider-test.tsx
@@ -12,10 +12,12 @@ import { ApiResponse } from '@/types/api';
 import { mockFetchSuccess, mockFetchError } from '@/mocks/mockFetch';
 
 const TestingComponent = () => {
-  const { reports, error }: CodesignDataContextType = useCodesignData();
+  const { reports, error, isLoading }: CodesignDataContextType =
+    useCodesignData();
   return (
     <View>
       <Text>Child Component</Text>
+      {isLoading && <Text>Loading</Text>}
       {reports.length && <Text>{JSON.stringify(reports)}</Text>}
       {error && <Text>{error}</Text>}
     </View>
@@ -29,6 +31,9 @@ describe('<CodesignDataProvider />', () => {
 
   describe('when fetching report data succeeds', () => {
     test('it provides report data', async () => {
+      // Mock getReportByBoundary to return a successful response after 2 seconds
+      jest.useFakeTimers();
+      const timeToFetchData = 2000;
       const reportData: ReportFormDetails[] = [
         createMockedReportFormDetails({ id: 111 }),
         createMockedReportFormDetails({ id: 222 }),
@@ -39,42 +44,63 @@ describe('<CodesignDataProvider />', () => {
         message: 'Success',
         data: reportData
       };
-      global.fetch = mockFetchSuccess(successResponse);
+      global.fetch = mockFetchSuccess(successResponse, timeToFetchData);
 
+      // When CodesignDataProvider is rendered
       render(
         <CodesignDataProvider>
           <TestingComponent />
         </CodesignDataProvider>
       );
 
+      // it should immediately render children and a loading state
+      expect(screen.getByText('Child Component')).toBeVisible();
+      expect(screen.getByText('Loading')).toBeVisible();
+
+      // When fetching the report data succeeds
+      jest.advanceTimersByTime(timeToFetchData);
+
+      // then it should render the report data
       const expectedReports = JSON.stringify(
         reportData.map((item) => new Report(item))
       );
-
-      const childComponent = await screen.findByText('Child Component');
       const reports = await screen.findByText(expectedReports);
-
-      expect(childComponent).toBeVisible();
       expect(reports).toBeVisible();
+
+      // and the loading state should be removed
+      expect(screen.queryByText('Loading')).toBeNull();
     });
   });
 
   describe('when fetching report data fails', () => {
     test('it provides an error', async () => {
-      global.fetch = mockFetchError();
+      // Mock getReportByBoundary to fail after 2 seconds
+      jest.useFakeTimers();
+      const timeToFetchData = 2000;
+      global.fetch = mockFetchError('backend error message', timeToFetchData);
+
+      // When CodesignDataProvider is rendered
       render(
         <CodesignDataProvider>
           <TestingComponent />
         </CodesignDataProvider>
       );
 
-      const childComponent = await screen.findByText('Child Component');
+      // it should immediately render children and a loading state
+      expect(screen.getByText('Child Component')).toBeVisible();
+      expect(screen.getByText('Loading')).toBeVisible();
+
+      // When fetching the report data fails
+      jest.advanceTimersByTime(timeToFetchData);
+
+      // then it should render the correct error message
       const errorText = await screen.findByText(
         'An error occurred while fetching reports.'
       );
-
-      expect(childComponent).toBeVisible();
       expect(errorText).toBeVisible();
+
+      // and the loading state should be removed
+      expect(screen.queryByText('Loading')).toBeNull();
     });
   });
 });

--- a/codesign/components/__tests__/provider/ModalProvider-test.tsx
+++ b/codesign/components/__tests__/provider/ModalProvider-test.tsx
@@ -1,0 +1,99 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react-native';
+import { Text, View, Modal, Pressable } from 'react-native';
+
+import { ModalProvider, useModal } from '@/components/provider/ModalProvider';
+
+const TestModalComponent = ({ modalName }: { modalName: string }) => {
+  const { isVisible, openModal, closeModal } = useModal(modalName);
+  return (
+    <View>
+      <Pressable onPress={openModal}>
+        <Text>{`Open ${modalName}`}</Text>
+      </Pressable>
+      <Modal visible={isVisible} testID={`${modalName}-modal`}>
+        <Text>{modalName}</Text>
+        <Pressable onPress={closeModal}>
+          <Text>{`Close ${modalName}`}</Text>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+};
+
+describe('<ModalProvider />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should open and close modal correctly', async () => {
+    // When rendering a modal
+    const modalName = 'test';
+    render(
+      <ModalProvider>
+        <TestModalComponent modalName={modalName} />
+      </ModalProvider>
+    );
+
+    // Then the modal should not be visible initially
+    expect(screen.queryByTestId(`${modalName}-modal`)).toBeNull();
+
+    // When the open button is pressed
+    const openModalButton = await screen.findByText(`Open ${modalName}`);
+    fireEvent.press(openModalButton);
+
+    // Then the modal should be visible
+    await waitFor(() => {
+      expect(screen.getByTestId(`${modalName}-modal`)).toBeVisible();
+    });
+
+    // When the close button is pressed
+    const closeModalButton = await screen.findByText(`Close ${modalName}`);
+    fireEvent.press(closeModalButton);
+
+    // Then the modal should no longer be visible
+    await waitFor(() => {
+      expect(screen.queryByTestId(`${modalName}-modal`)).toBeNull();
+    });
+  });
+
+  test('should open and close multiple modals correctly', async () => {
+    // When rendering multiple modals
+    const [modal1, modal2] = ['test1', 'test2'];
+    render(
+      <ModalProvider>
+        <TestModalComponent modalName={modal1} />
+        <TestModalComponent modalName={modal2} />
+      </ModalProvider>
+    );
+
+    // Then both modals should not be visible initially
+    expect(screen.queryByTestId(`${modal1}-modal`)).toBeNull();
+    expect(screen.queryByTestId(`${modal2}-modal`)).toBeNull();
+
+    // When modal 1 is opened
+    const openModalButton = await screen.findByText(`Open ${modal1}`);
+    fireEvent.press(openModalButton);
+
+    // Then only modal 1 should be visible
+    await waitFor(() => {
+      expect(screen.getByTestId(`${modal1}-modal`)).toBeVisible();
+    });
+    // And modal 2 should not be visible
+    expect(screen.queryByTestId(`${modal2}-modal`)).toBeNull();
+
+    // When modal 1 is closed
+    const closeModalButton = await screen.findByText(`Close ${modal1}`);
+    fireEvent.press(closeModalButton);
+
+    // Then modal 1 should no longer be visible
+    await waitFor(() => {
+      expect(screen.queryByTestId(`${modal1}-modal`)).toBeNull();
+    });
+    expect(screen.queryByTestId(`${modal2}-modal`)).toBeNull();
+  });
+});

--- a/codesign/components/provider/CodesignDataProvider.tsx
+++ b/codesign/components/provider/CodesignDataProvider.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { Report } from '@/types/Report';
 import { getReportByBoundary } from '@/api/report/getReportByBoundary';
 
-type CodesignDataContextType = {
+export type CodesignDataContextType = {
   reports: Report[];
   setReports: (reports: Report[]) => void;
   isLoading: boolean;
@@ -17,7 +17,9 @@ const CodesignDataContext = createContext<CodesignDataContextType | undefined>(
 export const useCodesignData = () => {
   const context = useContext(CodesignDataContext);
   if (!context) {
-    throw new Error('useData must be used within a CodesignDataProvider');
+    throw new Error(
+      'useCodesignData must be used within a CodesignDataProvider component'
+    );
   }
   return context;
 };

--- a/codesign/components/provider/ModalProvider.tsx
+++ b/codesign/components/provider/ModalProvider.tsx
@@ -11,7 +11,7 @@ const ModalContext = createContext<ModalContextType | undefined>(undefined);
 export const useModal = (name: string) => {
   const context = useContext(ModalContext);
   if (!context) {
-    throw new Error('useModal must be used within a ModalProvider');
+    throw new Error('useModal must be used within a ModalProvider component');
   }
   return {
     isVisible: context.isVisible(name),

--- a/codesign/mocks/mockFetch.ts
+++ b/codesign/mocks/mockFetch.ts
@@ -1,17 +1,24 @@
-export function mockFetchSuccess(data: any) {
-  return jest.fn(() =>
-    Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve(data)
-    })
-  ) as jest.Mock;
+export function mockFetchSuccess(data: any, delay = 0) {
+  return jest.fn(() => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          ok: true,
+          json: () => Promise.resolve(data)
+        });
+      }, delay);
+    });
+  }) as jest.Mock;
 }
-export function mockFetchError(errorMessage?: string) {
-  return jest.fn(() =>
-    Promise.resolve({
-      ok: false,
-      json: () =>
-        Promise.reject(new Error(errorMessage ?? 'Network response was not ok'))
-    })
-  ) as jest.Mock;
+export function mockFetchError(errorMessage: string, delay = 0) {
+  return jest.fn(() => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          ok: true,
+          json: () => Promise.reject(new Error(errorMessage))
+        });
+      }, delay);
+    });
+  }) as jest.Mock;
 }


### PR DESCRIPTION
#68 

# Summary
Add tests for CodesignDataProvider and ModalProvider.

# Details
Test the following expected behavior for CodesignDataProvider:

- [x] it initially starts off in a loading state, renders its children, then makes an api call to fetch reports. 
- [x] If api call is successful, it updates its context to store report data. 
- [x] If api call fails- it updates its context to store an error message.

Test the following expected behavior for ModalProvider:

- [x] it correctly updates modal visibility with openModal and closeModal methods
- [x] when there are multiple modals, it will open/close the correct modal

# Testing
All tests pass
Build succeeds, no runtime errors