### PR TITLE
Test Report Details Sheet component

### DIFF
--- a/codesign/components/__tests__/report/ReportDetailsSheet-test.tsx
+++ b/codesign/components/__tests__/report/ReportDetailsSheet-test.tsx
@@ -1,0 +1,72 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor
+} from '@testing-library/react-native';
+import { format } from 'date-fns';
+
+import { createMockedReportFormDetails } from '@/mocks/mockReport';
+import { Report } from '@/types/Report';
+import { mockReactNativeReanimated } from '@/mocks/mockReactNativeReanimated';
+import { mockBottomSheet } from '@/mocks/mockBottomSheet';
+
+describe('<ReportDetailsSheet />', () => {
+  // Mock third-party libraries
+  mockReactNativeReanimated();
+  const { mockedCloseBottomSheet } = mockBottomSheet();
+
+  const mockedReport = new Report(createMockedReportFormDetails());
+
+  const {
+    ReportDetailsSheet
+  } = require('@/components/report/ReportDetailsSheet');
+
+  test('renders expected report details', () => {
+    // When rendering the sheet
+    render(
+      <ReportDetailsSheet
+        report={mockedReport}
+        afterCloseCallback={jest.fn()}
+      />
+    );
+
+    // Image from report should be visible
+    expect(
+      screen.getByTestId('report-details-sheet-header-image')
+    ).toBeVisible();
+    // All report details should be visible
+    expect(screen.getByText(mockedReport.getTitle())).toBeVisible();
+    expect(
+      screen.getByText(format(mockedReport.getCreatedAt(), 'MMMM dd, yyyy'))
+    ).toBeVisible();
+    expect(screen.getByText('Details')).toBeVisible();
+    expect(screen.getByText(mockedReport.getDescription())).toBeVisible();
+  });
+
+  test('the close button closes the sheet', async () => {
+    // When rendering the sheet
+    render(
+      <ReportDetailsSheet
+        report={mockedReport}
+        afterCloseCallback={jest.fn()}
+      />
+    );
+
+    // The close button should be visible
+    expect(
+      screen.getByTestId('report-details-sheet-close-button')
+    ).toBeVisible();
+
+    // When the close button is pressed
+    const closeButton = await screen.findByTestId(
+      'report-details-sheet-close-button'
+    );
+    fireEvent.press(closeButton);
+
+    // Then the sheet should close
+    await waitFor(() => {
+      expect(mockedCloseBottomSheet).toHaveBeenCalled();
+    });
+  });
+});

--- a/codesign/components/report/ReportDetailsSheet.tsx
+++ b/codesign/components/report/ReportDetailsSheet.tsx
@@ -9,7 +9,7 @@ import Animated, {
   ReduceMotion
 } from 'react-native-reanimated';
 
-import { Report, ImageDetails } from '@/types/Report';
+import { Report } from '@/types/Report';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { ThemedView } from '@/components/ui/ThemedView';
 import { ThemedText } from '@/components/ui/ThemedText';
@@ -19,6 +19,7 @@ import { Spacing } from '@/constants/styles/Spacing';
 import { tamuColors } from '@/constants/Colors';
 import { ImageButton } from '@/components/ui/ImageButton';
 import { ThemedScrollView } from '../ui/ThemedScrollView';
+import { getImageSrc } from '@/utils/Image';
 
 const HALF_SCREEN = '30%';
 const FULL_SCREEN = '100%';
@@ -98,6 +99,7 @@ export function ReportDetailsSheet({
       handleStyle={styles.handleContainer}
       onChange={handleSheetChange}
       onClose={afterCloseCallback}
+      accessibilityLabel={'Report details sheet'}
     >
       <BottomSheetView
         style={{
@@ -118,6 +120,8 @@ export function ReportDetailsSheet({
             size={24}
             transparent={true}
             onPress={closeSheet}
+            accessibilityLabel="Close report details sheet"
+            testID="report-details-sheet-close-button"
           />
         </Animated.View>
 
@@ -125,8 +129,10 @@ export function ReportDetailsSheet({
           <Animated.View style={[styles.header, { height }]}>
             {/* TO DO: Add image loading and error states */}
             <Animated.Image
-              source={getImageSrc(report.getImages())}
+              source={getImageSrc(DEFAULT_IMAGE_SRC, report.getImages())}
               style={[styles.headerImage, { height }]}
+              testID={'report-details-sheet-header-image'}
+              accessibilityLabel={'Report details header image'}
             />
           </Animated.View>
           {isFullScreen ? (
@@ -146,7 +152,7 @@ export function ReportDetailsSheet({
 
 function ReportDetails({ report }: { report: Report }) {
   return (
-    <ThemedView style={styles.content}>
+    <ThemedView style={styles.content} testID="report-details-sheet-content">
       <ThemedView style={styles.contentSection}>
         <ThemedText type="title2" style={[styles.titleText]}>
           {report.getTitle()}
@@ -165,17 +171,6 @@ function ReportDetails({ report }: { report: Report }) {
     </ThemedView>
   );
 }
-
-const getImageSrc = (images: ImageDetails[]) => {
-  if (!images || images.length === 0) return DEFAULT_IMAGE_SRC;
-  if (typeof images[0].uri === 'string') {
-    return { uri: images[0].uri };
-  } else if (typeof images[0].base64 === 'string') {
-    return { uri: 'data:image/png;base64,' + images[0].base64 };
-  } else {
-    return images[0].uri;
-  }
-};
 
 const styles = StyleSheet.create({
   closeButtonContainer: {

--- a/codesign/mocks/mockBottomSheet.tsx
+++ b/codesign/mocks/mockBottomSheet.tsx
@@ -1,0 +1,30 @@
+import { View } from 'react-native';
+
+export function mockBottomSheet() {
+  const mockedCloseBottomSheet = jest.fn();
+  const mockedBottomSheet = jest.fn(function ({ children }: any, ref: any) {
+    if (ref) {
+      ref.current = {
+        close: mockedCloseBottomSheet
+      };
+    }
+    return <View>{children}</View>;
+  });
+  const mockedBottomSheetView = jest.fn(function ({ children }: any) {
+    return <View>{children}</View>;
+  });
+
+  jest.mock('@gorhom/bottom-sheet', () => {
+    const { forwardRef } = jest.requireActual('react');
+    return {
+      __esModule: true,
+      default: forwardRef(mockedBottomSheet),
+      BottomSheetView: mockedBottomSheetView
+    };
+  });
+
+  return {
+    mockedCloseBottomSheet,
+    mockedBottomSheet
+  };
+}

--- a/codesign/mocks/mockReactNativeReanimated.tsx
+++ b/codesign/mocks/mockReactNativeReanimated.tsx
@@ -1,0 +1,41 @@
+import { View, Image } from 'react-native';
+
+export function mockReactNativeReanimated() {
+  const mockedAnimated = {
+    View: jest.fn(({ children, style, ...rest }) => {
+      return (
+        <View style={style} {...rest}>
+          {children}
+        </View>
+      );
+    }),
+    Image: jest.fn(({ source, style, ...rest }) => {
+      return <Image source={source} style={style} {...rest} />;
+    })
+  };
+
+  jest.mock('react-native-reanimated', () => {
+    return {
+      __esModule: true,
+      default: mockedAnimated,
+      useSharedValue: jest.fn().mockReturnValue({
+        value: 0
+      }),
+      withTiming: jest.fn((value, config) => {
+        return {
+          value,
+          config
+        };
+      }),
+      Easing: {
+        inOut: jest.fn().mockReturnValue(0),
+        back: jest.fn().mockReturnValue(0)
+      },
+      ReduceMotion: {
+        System: 'system',
+        Always: 'always',
+        Never: 'never'
+      }
+    };
+  });
+}

--- a/codesign/utils/Image.ts
+++ b/codesign/utils/Image.ts
@@ -1,0 +1,20 @@
+import { ImageDetails } from '@/types/Report';
+
+export const getImageSrc = (
+  defaultSrc: any,
+  images: ImageDetails[]
+): ImageSource => {
+  if (!images || images.length === 0) return defaultSrc;
+  if (typeof images[0].uri === 'string') {
+    return { uri: images[0].uri };
+  } else if (typeof images[0].base64 === 'string') {
+    return { uri: 'data:image/png;base64,' + images[0].base64 };
+  } else {
+    if (!images[0].uri) return defaultSrc;
+    return images[0].uri;
+  }
+};
+
+type ImageSource = {
+  uri: string;
+};

--- a/codesign/utils/__tests__/Image-test.ts
+++ b/codesign/utils/__tests__/Image-test.ts
@@ -1,0 +1,60 @@
+import { ImageDetails } from '@/types/Report';
+import { getImageSrc } from '@/utils/Image';
+
+describe('getImageSrc()', () => {
+  const DEFAULT_SRC = { uri: 'default_image.png' };
+
+  test('returns default image source when no images are provided', () => {
+    const emptyImages: ImageDetails[] = [];
+    expect(getImageSrc(DEFAULT_SRC, emptyImages)).toEqual(DEFAULT_SRC);
+  });
+
+  test('returns valid URI', () => {
+    const mockedImageWithUri = { uri: 'image.png' };
+    const images: ImageDetails[] = [mockedImageWithUri];
+    const result = getImageSrc(DEFAULT_SRC, images);
+    expect(result).toEqual(mockedImageWithUri);
+  });
+
+  test('formats uri when image only has valid base64', () => {
+    const mockedImageWithBase64 = { base64: 'base64_string' };
+    const images: ImageDetails[] = [mockedImageWithBase64];
+    const result = getImageSrc(DEFAULT_SRC, images);
+    expect(result).toEqual({
+      uri: `data:image/png;base64,${mockedImageWithBase64.base64}`
+    });
+  });
+
+  test('extracts uri when image uri incorrectly stores an object', () => {
+    // this occurs when using getMockImage() to load images from assets/
+    const nestedUri = { uri: 'mocked_image.png' };
+    const images = [{ uri: nestedUri }];
+    const result = getImageSrc(DEFAULT_SRC, images);
+    expect(result).toEqual(nestedUri);
+  });
+
+  test('returns default image when invalid uri is provided', () => {
+    const invalidImageUri = { uri: null, base64: null };
+    const images = [invalidImageUri];
+    const result = getImageSrc(DEFAULT_SRC, images);
+    expect(result).toEqual(DEFAULT_SRC);
+  });
+
+  test('returns only image source when both uri and base64 are provided', () => {
+    const images: ImageDetails[] = [
+      { uri: 'image.png', base64: 'base64_string' }
+    ];
+    const result = getImageSrc(DEFAULT_SRC, images);
+    expect(result).toEqual({ uri: 'image.png' });
+  });
+
+  test('returns only the first image source when multiple images are provided', () => {
+    const images: ImageDetails[] = [
+      { uri: 'image1.png' },
+      { uri: 'image2.png' },
+      { base64: 'base64_string' }
+    ];
+    const result = getImageSrc(DEFAULT_SRC, images);
+    expect(result).toEqual({ uri: 'image1.png' });
+  });
+});


### PR DESCRIPTION
# Summary
The report details sheet renders when clicking on an icon on the map. 

# Details

Add the following modules used by this component: react-native-reanimated, @gorhom/bottom-sheet

Test that the report details sheet behaves as expected:

- [ ] It should render all the expected report information, include the first image, the title, and the description
- [ ] The close button should call the 3rd party library's method to close the sheet

# Testing
All tests pass
Build WIP