### PR TITLE
Automation for E2E testing with Expo EAS + Devicecloud.dev

### DIFF
--- a/.github/workflows/build-for-e2e.yml
+++ b/.github/workflows/build-for-e2e.yml
@@ -1,0 +1,85 @@
+name: Build Codesign on EAS Platform
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:20
+    steps:
+      - name: Check out CoDesign repository
+        uses: actions/checkout@v4
+
+      - name: Setup EAS with Expo Github Action
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          packager: npm
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./codesign
+
+      - name: Build Codesign on EAS Platform
+        run: eas build --non-interactive --platform ios --profile preview-simulator
+        working-directory: ./codesign
+
+  download_artifact:
+    runs-on: ubuntu-latest
+    container:
+      image: node:20
+    needs: build
+    steps:
+      - name: Setup EAS with Expo Github Action
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          packager: npm
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Get latest build info
+        run: |
+          eas build:list --limit 1 --platform ios --json --non-interactive > build-info.json
+          cat build-info.json
+        working-directory: ./codesign
+
+      - name: Download latest iOS build tarball
+        run: |
+          DOWNLOAD_URL=$(grep -o 'https://[^"]*\.tar\.gz' build-info.json | head -n 1)
+          echo "Download URL: $DOWNLOAD_URL"
+          curl -L "$DOWNLOAD_URL" -o ios-build.tar.gz
+        working-directory: ./codesign
+
+      - name: Extract iOS build
+        run: |
+          mkdir -p build-output
+          tar -xzf ios-build.tar.gz -C build-output
+        working-directory: ./codesign
+
+      - name: Zip the iOS build and include date in the filename
+        run: |
+          cd build-output
+          DATE=$(date +'%Y-%m-%d')
+          ZIP_NAME="CoDesign-$DATE.zip"
+          zip -r "$ZIP_NAME" CoDesign.app
+          echo "ZIP_NAME=$ZIP_NAME" >> $GITHUB_ENV
+        working-directory: ./codesign
+
+      - name: Upload the iOS build artifact to GitHub
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: ${{ env.ZIP_NAME }}
+          path: ./codesign/build-output/${{ env.ZIP_NAME }}
+          retention-days: 30
+
+      - name: Upload iOS build and E2E test file to Devicecloud.dev for automated E2E testing
+        run: |
+          dcd cloud --apiKey ${{ secrets.DCD_API_KEY }} --app-file build-output/${{ env.ZIP_NAME }} --flows ./e2e/ --ios-device iphone-15 --ios-version 17 --name ${{ env.ZIP_NAME }}
+        working-directory: ./codesign

--- a/.github/workflows/build-for-e2e.yml
+++ b/.github/workflows/build-for-e2e.yml
@@ -15,11 +15,15 @@ jobs:
       - name: Check out CoDesign repository
         uses: actions/checkout@v4
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Setup EAS with Expo Github Action
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
-          packager: npm
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
@@ -27,7 +31,7 @@ jobs:
         working-directory: ./codesign
 
       - name: Build Codesign on EAS Platform
-        run: eas build --non-interactive --platform ios --profile preview-simulator
+        run: eas build --platform ios --profile preview-simulator
         working-directory: ./codesign
 
   download_artifact:

--- a/codesign/e2e/create-and-view-report.yaml
+++ b/codesign/e2e/create-and-view-report.yaml
@@ -36,16 +36,15 @@ appId: com.urbanailab.codesign
 
 # When swipe to view Indoor fields
 - swipe:
-    start: 50%, 60%
-    end: 50%, 40%
+    start: 50%, 70%
+    end: 50%, 50%
 
 # and fill in the fields
 - tapOn: Enter building name
 - inputText: "Test Building"
 
-- tapOn: Enter floor number
-- eraseText
-- inputText: 2
+- assertVisible: Floor Number*
+- assertVisible: 1
 - tapOn: Report Details # close keyboard without using flakey hideKeyboard
 
 # and swipe to view Report Details section
@@ -64,7 +63,7 @@ appId: com.urbanailab.codesign
 # Then one uploaded image and two placeholders should be visible
 - waitForAnimationToEnd
 - assertVisible:
-    id: uploaded-image-0
+    id: uploaded-image-1
 - assertVisible: Image Placeholder 1 of 2
 - assertVisible: Image Placeholder 2 of 2
 
@@ -113,13 +112,3 @@ appId: com.urbanailab.codesign
     id: report-details-sheet-date
 - assertVisible:
     id: report-details-sheet-description
-
-
-# When close the report details sheet
-- tapOn:
-    id: report-details-sheet-close-button
-- waitForAnimationToEnd
-
-# Then the report details sheet should be closed
-- assertNotVisible:
-    id: report-details-sheet-header-image


### PR DESCRIPTION
# Summary
Create automation to build Codesign app on EAS's cloud, download the PR, then upload the app binary + e2e test to devicecloud.dev for automated e2e testing on their cloud platform

# Details
Job 1: build
    - Set up node environment
    - Set up EAS credentials
    - Install deps
    - Run build command

Job 2: download-artifact
    - Only run if build jobs succeeds
    - Get most recent build info and extract download URl
    - Download app binary from EAS and extract it to `build-output/` folder
    - Zip the .app file
    - Submit the zipped app + test files in e2e folder to devicecloud.dev cloud platform for testing

# Testing 
Testing Plan:
    - Merge these changes to `develop` branch
    - Trigger workflow manually and debug with the github hosted test runner
    - Continue using this same branch to resolve any issues
    - Merge to `develop`

Once workflow is verified to work correctly with develop branch, will update the trigger to run the jobs when new changes are pushed to `main` branch