### PR TITLE
Add git to job environment

### DIFF
--- a/.github/workflows/build-for-e2e.yml
+++ b/.github/workflows/build-for-e2e.yml
@@ -6,9 +6,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: node:20
     steps:
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get install -y git
+
       - name: Check out CoDesign repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
# Summary
Upgrade git in the job's environment so git works properly.

# Description

## Issue
When testing out the build and submit-e2e jobs, [this error](https://github.com/TAMIDS-Urban-AI-Lab/CoDesign/actions/runs/15002321086/job/42152225714#step:7:11) was thrown:
```
Run eas build --platform ios --profile preview-simulator --non-interactive
It looks like you haven't initialized the git repository yet.
EAS requires you to use a git repository for your project.
```
Upon further investigation, noticed: `fatal: not in a git directory` being logged in the `npm ci` command.

## Root cause
The node image doesn't come with git by default. For some reason, there is a mismatch between my local docker image and Github's image

I was able to reproduce the error with nektos/act by removing the docker container version (container: image:) syntax

## Solution
Specifically download git to the job's env

# Testing
Run the following command:
`act workflow_dispatch -j build --container-architecture linux/amd64 --secret-file .secrets --artifact-server-path /tmp/artifacts` to test locally and ensure that the error no longer appears.

