### PR TITLE
Unlink two workflow jobs and have no container specified

### DIFF
--- a/.github/workflows/build-for-e2e.yml
+++ b/.github/workflows/build-for-e2e.yml
@@ -6,9 +6,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: node:20
     steps:
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get install -y git
+
       - name: Check out CoDesign repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-for-e2e.yml
+++ b/.github/workflows/build-for-e2e.yml
@@ -7,11 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install git
-        run: |
-          apt-get update
-          apt-get install -y git
-
       - name: Check out CoDesign repository
         uses: actions/checkout@v4
 
@@ -31,15 +26,16 @@ jobs:
         working-directory: ./codesign
 
       - name: Build Codesign on EAS Platform
-        run: eas build --platform ios --profile preview-simulator --non-interactive
+        run: EAS_NO_VCS=1 eas build --platform ios --profile preview-simulator --non-interactive
         working-directory: ./codesign
 
   submit-e2e:
     runs-on: ubuntu-latest
-    container:
-      image: node:20
-    needs: build
     steps:
+      - name: Install Act dependencies
+        if: ${{ env.ACT }}
+        run: apt-get update && apt-get install sudo -y
+
       - name: Check out CoDesign repository
         uses: actions/checkout@v4
 
@@ -57,10 +53,10 @@ jobs:
       - name: Install Devicecloud CLI
         run: npm install -g @devicecloud.dev/dcd
 
-      - name: Install zip tool
+      - name: Install curl and zip
         run: |
-          apt-get update
-          apt-get install zip
+          sudo apt-get update
+          sudo apt-get install zip curl -y
 
       - name: Install project dependencies
         run: npm ci


### PR DESCRIPTION
# Summary
Unlink two jobs to test both and have no container specified

# Description
- remove docker container: image:node:20 because the behavior is different between Act and Github Actions test runner
- add sudo since that will be required for Github Action test runner, but act doesn't support it so add an act only command to install sudo
- assume Github Action test runner does not have curl, so install it with zip

# Testing
Run the following command to test both `build` and `submit-e2e`
```
act workflow_dispatch -j submit-e2e --container-architecture linux/amd64 --secret-file .secrets --artifact-server-path /tmp/artifacts
```

Runs pass
