### PR TITLE
Remove git from job env and relink jobs

### DIFF
--- a/.github/workflows/build-for-e2e.yml
+++ b/.github/workflows/build-for-e2e.yml
@@ -31,6 +31,7 @@ jobs:
 
   submit-e2e:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Install Act dependencies
         if: ${{ env.ACT }}

--- a/.github/workflows/build-for-e2e.yml
+++ b/.github/workflows/build-for-e2e.yml
@@ -7,11 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install git
-        run: |
-          apt-get update
-          apt-get install -y git
-
       - name: Check out CoDesign repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
# Summary
Remove git from job env and relink jobs

# Description
- Since we are setting the EAS_NO_VCS=1 flag to tell EAS not to use Version Control, we don't need git -> hence, removing
- Only run submit-e2e if build passes

# Testing
Run the command and passes
```
 act workflow_dispatch -j submit-e2e --container-architecture linux/amd64 --secret-file .secrets --artifact-server-path /tmp/artifacts
```
