### PR TITLE
Fix Profile Page Text

### DIFF
--- a/codesign/components/profile/EditProfile.tsx
+++ b/codesign/components/profile/EditProfile.tsx
@@ -15,10 +15,29 @@ const styles = StyleSheet.create({
   profileContainer: {
     gap: Spacing.large
   },
-  actionContainer: {
+  liftedActionCard: {
     padding: Spacing.large,
     ...Border.roundedSmall,
     ...Border.elevated
+  },
+  actionCardRow: {
+    ...Layout.row,
+    gap: Spacing.small
+  },
+  profileImage: {
+    width: PROFILE_IMAGE_SIZE,
+    height: PROFILE_IMAGE_SIZE,
+    ...Border.roundedSmall,
+    backgroundColor: tamuColors.primaryBrandDark
+  },
+  actionsList: {
+    ...Layout.col,
+    gap: Spacing.small
+  },
+  actionListItem: {
+    ...Layout.row,
+    ...Layout.alignCenter,
+    gap: Spacing.small
   }
 });
 
@@ -36,22 +55,17 @@ export function EditProfile({
   return (
     <ThemedView style={[styles.profileContainer, style]}>
       <ThemedText type="title3">{displayName}</ThemedText>
-      <ThemedView style={[styles.actionContainer]}>
-        <ThemedView style={[Layout.row, { gap: Spacing.medium }]}>
+      <ThemedView style={[styles.liftedActionCard]}>
+        <ThemedView style={[styles.actionCardRow]}>
           <Image
             source={
               profileImageSrc ?? require('@/assets/images/react-logo.png')
             }
-            style={{
-              width: PROFILE_IMAGE_SIZE,
-              height: PROFILE_IMAGE_SIZE,
-              ...Border.roundedSmall,
-              backgroundColor: tamuColors.primaryBrandDark
-            }}
+            style={styles.profileImage}
             testID="profile-image"
           />
-          <ThemedView style={[Layout.col, { gap: Spacing.small }]}>
-            <Pressable style={[Layout.row, { gap: Spacing.small }]}>
+          <ThemedView style={[styles.actionsList]}>
+            <Pressable style={[styles.actionListItem]}>
               <IconSymbol
                 size={EDIT_ICON_SIZE}
                 name="pencil"
@@ -59,7 +73,7 @@ export function EditProfile({
               />
               <ThemedText type="paragraph">Edit Display Name</ThemedText>
             </Pressable>
-            <Pressable style={[Layout.row, { gap: Spacing.small }]}>
+            <Pressable style={[styles.actionListItem]}>
               <IconSymbol
                 size={EDIT_ICON_SIZE}
                 name="camera.fill"

--- a/codesign/constants/styles/Typography.ts
+++ b/codesign/constants/styles/Typography.ts
@@ -18,12 +18,12 @@ export const Typography = {
   },
 
   paragraph: {
-    fontSize: 16,
+    fontSize: 14,
     lineHeight: 24,
     fontFamily: 'OpenSansRegular'
   },
   paragraphBold: {
-    fontSize: 16,
+    fontSize: 14,
     lineHeight: 24,
     fontFamily: 'OpenSansBold'
   },


### PR DESCRIPTION
Resolves #59

# Summary
The 'Edit display name' and 'Choose Profile Picture' actions were breaking the container, fixed them to not break out of container

# Description
Make paragraph text smaller
Move inline styles

# Testing
Check UI.
Automated tests pass.

Before:
<img width="413" alt="Screenshot 2025-05-16 at 3 37 47 PM" src="https://github.com/user-attachments/assets/8f10c798-8552-42a2-9688-1bb013c114df" />
After:
<img width="425" alt="Screenshot 2025-05-16 at 3 41 20 PM" src="https://github.com/user-attachments/assets/1f96b5ab-7f39-4b55-ae67-ca6e19cb8469" />

