### PR TITLE
Move spy approach to using mock util

### DIFF
--- a/codesign/components/__tests__/ui/ThemedModal-test.tsx
+++ b/codesign/components/__tests__/ui/ThemedModal-test.tsx
@@ -5,10 +5,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import { View } from 'react-native';
 
-import { ThemedModal } from '@/components/ui/ThemedModal';
-import * as ColorSchemeHook from '@/hooks/useColorScheme';
+import { mockUseColorScheme } from '@/mocks/mockUseColorScheme';
 
 describe('<ThemedModal />', () => {
+  const { mockedUseColorScheme } = mockUseColorScheme();
+  const { ThemedModal } = require('@/components/ui/ThemedModal');
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -49,9 +51,9 @@ describe('<ThemedModal />', () => {
   });
 
   test('applies light color in light theme', () => {
+    mockedUseColorScheme.mockReturnValue('light');
     const lightColor = '#ffffff';
     const darkColor = '#000000';
-    jest.spyOn(ColorSchemeHook, 'useColorScheme').mockReturnValue('light');
 
     render(
       <ThemedModal testID="modal" lightColor={lightColor} darkColor={darkColor}>
@@ -66,9 +68,9 @@ describe('<ThemedModal />', () => {
   });
 
   test('applies dark color in dark theme', () => {
+    mockedUseColorScheme.mockReturnValue('dark');
     const lightColor = '#ffffff';
     const darkColor = '#000000';
-    jest.spyOn(ColorSchemeHook, 'useColorScheme').mockReturnValue('dark');
 
     render(
       <ThemedModal testID="modal" lightColor={lightColor} darkColor={darkColor}>

--- a/codesign/components/__tests__/ui/ThemedRadioButton-test.tsx
+++ b/codesign/components/__tests__/ui/ThemedRadioButton-test.tsx
@@ -1,9 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react-native';
 
-import { ThemedRadioButton } from '@/components/ui/ThemedRadioButton';
-import * as ColorSchemeHooks from '@/hooks/useColorScheme';
+import { mockUseColorScheme } from '@/mocks/mockUseColorScheme';
 
 describe('<ThemedRadioButton />', () => {
+  const { mockedUseColorScheme } = mockUseColorScheme();
+  const { ThemedRadioButton } = require('@/components/ui/ThemedRadioButton');
   const mockOnPress = jest.fn();
 
   beforeEach(() => {
@@ -65,10 +66,8 @@ describe('<ThemedRadioButton />', () => {
   });
 
   describe('theme modes', () => {
-    const mockUseColorScheme = jest.spyOn(ColorSchemeHooks, 'useColorScheme');
-
     test('renders correct icons in light mode', () => {
-      mockUseColorScheme.mockReturnValue('light');
+      mockedUseColorScheme.mockReturnValue('light');
       render(
         <ThemedRadioButton
           title="Test Radio"
@@ -84,7 +83,7 @@ describe('<ThemedRadioButton />', () => {
     });
 
     test('renders correct icons in dark mode', () => {
-      mockUseColorScheme.mockReturnValue('dark');
+      mockedUseColorScheme.mockReturnValue('dark');
       render(
         <ThemedRadioButton
           title="Test Radio"
@@ -97,10 +96,6 @@ describe('<ThemedRadioButton />', () => {
       expect(image.props.source.testUri).toMatch(
         /radio-button\/checked-dark\.png$/
       );
-    });
-
-    afterAll(() => {
-      mockUseColorScheme.mockRestore();
     });
   });
 });

--- a/codesign/components/__tests__/ui/ThemedView-test.tsx
+++ b/codesign/components/__tests__/ui/ThemedView-test.tsx
@@ -1,16 +1,17 @@
 import { render, screen } from '@testing-library/react-native';
-import * as ColorSchemeHook from '@/hooks/useColorScheme';
 
-import { ThemedView } from '@/components/ui/ThemedView';
+import { mockUseColorScheme } from '@/mocks/mockUseColorScheme';
 import { tamuColors } from '@/constants/Colors';
 
 describe('<ThemedView />', () => {
+  const { mockedUseColorScheme } = mockUseColorScheme();
+  const { ThemedView } = require('@/components/ui/ThemedView');
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   test('renders with default background color in light theme', () => {
-    jest.spyOn(ColorSchemeHook, 'useColorScheme').mockReturnValue('light');
+    mockedUseColorScheme.mockReturnValue('light');
     render(<ThemedView testID="themed-view" />);
     const view = screen.getByTestId('themed-view');
     expect(view).toBeVisible();
@@ -20,9 +21,9 @@ describe('<ThemedView />', () => {
   });
 
   test('applies custom light color in light theme', () => {
+    mockedUseColorScheme.mockReturnValue('light');
     const lightColor = '#ffffff';
     const darkColor = '#000000';
-    jest.spyOn(ColorSchemeHook, 'useColorScheme').mockReturnValue('light');
     render(
       <ThemedView
         testID="themed-view"
@@ -38,9 +39,9 @@ describe('<ThemedView />', () => {
   });
 
   test('applies custom dark color in dark theme', () => {
+    mockedUseColorScheme.mockReturnValue('dark');
     const lightColor = '#ffffff';
     const darkColor = '#000000';
-    jest.spyOn(ColorSchemeHook, 'useColorScheme').mockReturnValue('dark');
     render(
       <ThemedView
         testID="themed-view"


### PR DESCRIPTION
# Summary
Got feedback that the mock util was not working. I've investigated the issue and created this PR as an example. 

TLDR; I recommend following approach 1 when mocking + importing components in future tests. See the in depth explanation below!

## Approach 1
```
const { mockedUseColorScheme } = mockUseColorScheme();
const { ThemedRadioButton } = require('@/components/ui/ThemedRadioButton'); // import component AFTER mocks
```

# Description

## The problem
Setting up a mock AFTER importing the component that needs to be tested (see incorrect usage below)

## Incorrect usage
```
import { ThemedRadioButton } from '@/components/ui/ThemedRadioButton'; // this is a static import
... other imports here...

const { mockedUseColorScheme } = mockUseColorScheme(); // mock is set up AFTER the component is imported
```

## Approach 1 - Works and currently in use
Root cause: Using a static import approach to import ThemedRadioButton i.e. `import { ThemedRadioButton } from '@/components/ui/ThemedRadioButton';` will process and cache the module's dependencies BEFORE the mock is set up. This means that it will use the original version of useColorScheme- the mock is not used.

Hence, using the CommonJS approach of`require` resolves this by loading in the module synchronously. This means that the component is loaded AFTER the mock is set up and uses the mocked useColorScheme!
```
const { mockedUseColorScheme } = mockUseColorScheme();
const { ThemedRadioButton } = require('@/components/ui/ThemedRadioButton');
```


## Approach 2 - Works, not currently in use
Due to the situation mentioned above, jest tries to resolve the ordering issue by using **hoisting**. So, with hoisting, any `jest.mock` will automatically create the mock BEFORE importing static modules (even if your line of code is after the static import). But... this adds some complexity.

In order to save a reference to the mocked function, we are required to use a higher order function (aka factory function). This is referring to: `() => mockedUseColorScheme()` in the example below. 

Issue:`jest.mock` calls are hoisted to be run before static imports but other variables i.e. `mockedUseColorScheme` are not hoisted with it and would resolve undefined.
Solution: To bridge this gap, we wrap`mockUseColorScheme` with the higher order function, so it is not called until it is used in the test- at that point, it will be defined!
```
import { ThemedRadioButton } from '@/components/ui/ThemedRadioButton';

const mockedUseColorScheme = jest.fn();

jest.mock('@/hooks/useColorScheme', () => {
  return {
    useColorScheme: () => mockedUseColorScheme() // using a factory function 

  };
});
```

## Incorrect usage
```
import { ThemedRadioButton } from '@/components/ui/ThemedRadioButton';

const mockedUseColorScheme = jest.fn();  // not hoisted!!

jest.mock('@/hooks/useColorScheme', () => {
  return {
    useColorScheme: mockedUseColorScheme // mockedUseColorScheme will evaluate to undefined during hoisting
  };
});
```

## Summary
Although Approach 2 works, it requires a large chunk of code to be set up in every testing file, hence I went with approach 1 (creating the mockUseColorScheme and returning a reference to the mocked function) to be more re-usable and handle the nitty gritty of mocking logic - it only requires 2 lines in future test files!

# Testing
Tests pass!