### PR TITLE
Save AR suggestion to report form

### DIFF
--- a/codesign/components/__tests__/report/SuggestionUpload-test.tsx
+++ b/codesign/components/__tests__/report/SuggestionUpload-test.tsx
@@ -22,7 +22,7 @@ describe('<SuggestionUpload />', () => {
 
     // Then show the suggestion message
     expect(
-      screen.getByText('Would you like to suggest an improvement?')
+      screen.getByText('Suggest an improvement with Augmented Reality')
     ).toBeVisible();
 
     // and show the SUGGEST button

--- a/codesign/components/augmented-reality/ARUserInterface.tsx
+++ b/codesign/components/augmented-reality/ARUserInterface.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { ImageButton } from '@/components/ui/ImageButton';
 import { ThemedText } from '@/components/ui/ThemedText';
@@ -67,11 +67,6 @@ export function ARUserInterface({
     transform: [{ scale: suggestionImageScale.value }]
   }));
 
-  /* Hide UI when taking a screenshot */
-  if (!showEntireUI) {
-    return null;
-  }
-
   const setMenuDisplay = (display: 'none' | 'flex') => {
     return `
       document.getElementById('container').style.display = '${display}';
@@ -129,11 +124,27 @@ export function ARUserInterface({
     AR_UI_TABS.ITEM_MENU
   ].includes(currentTab);
 
-  maybeAnimatesuggestionImage(
-    isConfirmSuggestionTabActive,
-    suggestionImageOpacity,
-    suggestionImageScale
-  );
+  useEffect(() => {
+    if (isConfirmSuggestionTabActive) {
+      suggestionImageOpacity.value = withTiming(1, {
+        duration: 400,
+        easing: Easing.out(Easing.ease)
+      });
+      suggestionImageScale.value = withTiming(1, {
+        duration: 400,
+        easing: Easing.out(Easing.ease)
+      });
+    } else {
+      suggestionImageOpacity.value = 0;
+      suggestionImageScale.value = 0.95;
+    }
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [currentTab]);
+
+  /* Hide UI when taking a screenshot */
+  if (!showEntireUI) {
+    return null;
+  }
 
   return (
     <>
@@ -253,26 +264,6 @@ export function ARUserInterface({
       )}
     </>
   );
-}
-
-function maybeAnimatesuggestionImage(
-  isConfirmSuggestionTabActive: boolean,
-  suggestionImageOpacity: SharedValue<number>,
-  suggestionImageScale: SharedValue<number>
-) {
-  if (isConfirmSuggestionTabActive) {
-    suggestionImageOpacity.value = withTiming(1, {
-      duration: 400,
-      easing: Easing.out(Easing.ease)
-    });
-    suggestionImageScale.value = withTiming(1, {
-      duration: 400,
-      easing: Easing.out(Easing.ease)
-    });
-  } else {
-    suggestionImageOpacity.value = 0;
-    suggestionImageScale.value = 0.95;
-  }
 }
 
 const styles = StyleSheet.create({

--- a/codesign/components/augmented-reality/ARUserInterface.tsx
+++ b/codesign/components/augmented-reality/ARUserInterface.tsx
@@ -14,6 +14,7 @@ import { Border } from '@/constants/styles/Border';
 import { useARContext } from '@/components/augmented-reality/ARProvider';
 import { ScreenshotCapture } from '@/components/augmented-reality/ScreenshotCapture';
 import { LEFT_ARROW_SRC } from '@/constants/ImagePaths';
+import { ImageDetails } from '@/types/Report';
 
 type AR_UI_TAB = 'INITIAL' | 'ITEM_MENU' | 'SCREEN_CAPTURE';
 
@@ -28,7 +29,7 @@ export function ARUserInterface({
   handleSaveSuggestion
 }: {
   handleBackButton: () => void;
-  handleSaveSuggestion: () => void;
+  handleSaveSuggestion: (suggestion: ImageDetails) => void;
 }) {
   const { nudgeText, setNudgeTextWithReset, maybeHideNudgeText, webViewRef } =
     useARContext();

--- a/codesign/components/augmented-reality/ARUserInterface.tsx
+++ b/codesign/components/augmented-reality/ARUserInterface.tsx
@@ -309,7 +309,6 @@ const styles = StyleSheet.create({
     ...Border.roundedSmall
   },
   confirmSuggestionContainer: {
-    // ...Layout.flex,
     position: 'absolute',
     top: 0,
     left: 0,
@@ -317,23 +316,16 @@ const styles = StyleSheet.create({
     bottom: 0,
     ...Layout.center,
     padding: Spacing.large,
-    // backgroundColor: 'red',
-    // ...Layout.justifyCenter,
-    // ...Layout.alignCenter,
     zIndex: 1
   },
   suggestionImage: {
     width: '100%',
     height: '80%',
     resizeMode: 'cover',
-    // backgroundColor: tamuColors.gray200,
-    // width: '100%',
-    // height: '100%',
     ...Border.roundedSmall
   },
   confirmSuggestionActions: {
     ...Layout.row,
-    // ...Layout.justifySpaceBetween,
     ...Layout.center,
     gap: Spacing.medium,
     marginTop: Spacing.medium

--- a/codesign/components/augmented-reality/ARUserInterface.tsx
+++ b/codesign/components/augmented-reality/ARUserInterface.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Image } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { useState } from 'react';
 
 import { ImageButton } from '@/components/ui/ImageButton';
@@ -15,7 +15,14 @@ import { useARContext } from '@/components/augmented-reality/ARProvider';
 import { ScreenshotCapture } from '@/components/augmented-reality/ScreenshotCapture';
 import { LEFT_ARROW_SRC } from '@/constants/ImagePaths';
 import { ImageDetails } from '@/types/Report';
-import { TextButton } from '../ui/TextButton';
+import { TextButton } from '@/components/ui/TextButton';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+  SharedValue
+} from 'react-native-reanimated';
 
 type AR_UI_TAB =
   | 'INITIAL'
@@ -50,6 +57,19 @@ export function ARUserInterface({
 
   const [currentTab, setCurrentTab] = useState<AR_UI_TAB>(AR_UI_TABS.INITIAL);
   const [showEntireUI, setShowEntireUI] = useState<boolean>(true);
+
+  const suggestionImageOpacity: SharedValue<number> = useSharedValue(0);
+  const suggestionImageScale: SharedValue<number> = useSharedValue(0.95);
+
+  const suggestionImageAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: suggestionImageOpacity.value,
+    transform: [{ scale: suggestionImageScale.value }]
+  }));
+
+  /* Hide UI when taking a screenshot */
+  if (!showEntireUI) {
+    return null;
+  }
 
   const setMenuDisplay = (display: 'none' | 'flex') => {
     return `
@@ -110,10 +130,11 @@ export function ARUserInterface({
     AR_UI_TABS.ITEM_MENU
   ].includes(currentTab);
 
-  /* Hide UI when taking a screenshot */
-  if (!showEntireUI) {
-    return null;
-  }
+  maybeAnimatesuggestionImage(
+    isConfirmSuggestionTabActive,
+    suggestionImageOpacity,
+    suggestionImageScale
+  );
 
   return (
     <>
@@ -189,9 +210,9 @@ export function ARUserInterface({
           ]}
           transparent={true}
         >
-          <Image
+          <Animated.Image
             source={{ uri: suggestions[0].uri }}
-            style={styles.suggestionImage}
+            style={[styles.suggestionImage, suggestionImageAnimatedStyle]}
             accessibilityLabel={'Uploaded suggestion'}
             testID={`uploaded-suggestion`}
           />
@@ -231,6 +252,26 @@ export function ARUserInterface({
       )}
     </>
   );
+}
+
+function maybeAnimatesuggestionImage(
+  isConfirmSuggestionTabActive: boolean,
+  suggestionImageOpacity: SharedValue<number>,
+  suggestionImageScale: SharedValue<number>
+) {
+  if (isConfirmSuggestionTabActive) {
+    suggestionImageOpacity.value = withTiming(1, {
+      duration: 400,
+      easing: Easing.out(Easing.ease)
+    });
+    suggestionImageScale.value = withTiming(1, {
+      duration: 400,
+      easing: Easing.out(Easing.ease)
+    });
+  } else {
+    suggestionImageOpacity.value = 0;
+    suggestionImageScale.value = 0.95;
+  }
 }
 
 const styles = StyleSheet.create({

--- a/codesign/components/augmented-reality/ARUserInterface.tsx
+++ b/codesign/components/augmented-reality/ARUserInterface.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Image } from 'react-native';
 import { useState } from 'react';
 
 import { ImageButton } from '@/components/ui/ImageButton';
@@ -15,21 +15,31 @@ import { useARContext } from '@/components/augmented-reality/ARProvider';
 import { ScreenshotCapture } from '@/components/augmented-reality/ScreenshotCapture';
 import { LEFT_ARROW_SRC } from '@/constants/ImagePaths';
 import { ImageDetails } from '@/types/Report';
+import { TextButton } from '../ui/TextButton';
 
-type AR_UI_TAB = 'INITIAL' | 'ITEM_MENU' | 'SCREEN_CAPTURE';
+type AR_UI_TAB =
+  | 'INITIAL'
+  | 'ITEM_MENU'
+  | 'SCREEN_CAPTURE'
+  | 'CONFIRM_SUGGESTION';
 
 const AR_UI_TABS: Record<string, AR_UI_TAB> = {
   INITIAL: 'INITIAL',
   ITEM_MENU: 'ITEM_MENU',
-  SCREEN_CAPTURE: 'SCREEN_CAPTURE'
+  SCREEN_CAPTURE: 'SCREEN_CAPTURE',
+  CONFIRM_SUGGESTION: 'CONFIRM_SUGGESTION'
 } as const;
 
 export function ARUserInterface({
+  suggestions,
   handleBackButton,
-  handleSaveSuggestion
+  handleSaveSuggestions,
+  closeARModal
 }: {
+  suggestions: ImageDetails[];
   handleBackButton: () => void;
-  handleSaveSuggestion: (suggestion: ImageDetails) => void;
+  handleSaveSuggestions: (suggestions: ImageDetails[]) => void;
+  closeARModal: () => void;
 }) {
   const { nudgeText, setNudgeTextWithReset, maybeHideNudgeText, webViewRef } =
     useARContext();
@@ -78,9 +88,27 @@ export function ARUserInterface({
     }
   };
 
-  const hideItemMenuButton = currentTab === AR_UI_TABS.INITIAL;
   const isCameraButtonActive = currentTab === AR_UI_TABS.SCREEN_CAPTURE;
   const isItemMenuButtonActive = currentTab === AR_UI_TABS.ITEM_MENU;
+  const isConfirmSuggestionTabActive =
+    currentTab === AR_UI_TABS.CONFIRM_SUGGESTION;
+
+  const showCameraButton = [
+    AR_UI_TABS.INITIAL,
+    AR_UI_TABS.SCREEN_CAPTURE,
+    AR_UI_TABS.ITEM_MENU
+  ].includes(currentTab);
+
+  const showMenuItemsButton = [
+    AR_UI_TABS.SCREEN_CAPTURE,
+    AR_UI_TABS.ITEM_MENU
+  ].includes(currentTab);
+
+  const showBackButton = [
+    AR_UI_TABS.INITIAL,
+    AR_UI_TABS.SCREEN_CAPTURE,
+    AR_UI_TABS.ITEM_MENU
+  ].includes(currentTab);
 
   /* Hide UI when taking a screenshot */
   if (!showEntireUI) {
@@ -89,23 +117,31 @@ export function ARUserInterface({
 
   return (
     <>
-      <ImageButton
-        source={LEFT_ARROW_SRC[colorScheme]}
-        size={30}
-        spacing={Spacing.medium}
-        onPress={handleBackButton}
-        style={[styles.backButton, { backgroundColor: transparentBackground }]}
-        testID="close-ar-modal-button"
-        transparent={true}
-        accessibilityLabel="Close Suggestion Modal"
-      />
-      {isCameraButtonActive && (
-        <ScreenshotCapture
-          handleSaveSuggestion={handleSaveSuggestion}
-          setShowEntireUI={setShowEntireUI}
+      {showBackButton && (
+        <ImageButton
+          source={LEFT_ARROW_SRC[colorScheme]}
+          size={30}
+          spacing={Spacing.medium}
+          onPress={handleBackButton}
+          style={[
+            styles.backButton,
+            { backgroundColor: transparentBackground }
+          ]}
+          testID="close-ar-modal-button"
+          transparent={true}
+          accessibilityLabel="Close Suggestion Modal"
         />
       )}
-      {!hideItemMenuButton && (
+      {isCameraButtonActive && (
+        <ScreenshotCapture
+          handleSaveSuggestions={handleSaveSuggestions}
+          setShowEntireUI={setShowEntireUI}
+          afterScreenshotCallback={() => {
+            setCurrentTab(AR_UI_TABS.CONFIRM_SUGGESTION);
+          }}
+        />
+      )}
+      {showMenuItemsButton && (
         <>
           <ImageButton
             source={
@@ -126,21 +162,61 @@ export function ARUserInterface({
           />
         </>
       )}
-      <ImageButton
-        source={
-          CAMERA_SRC[colorScheme][isCameraButtonActive ? 'active' : 'inactive']
-        }
-        size={24}
-        onPress={() => switchToTab(AR_UI_TABS.SCREEN_CAPTURE)}
-        style={[
-          styles.cameraButton,
-          { backgroundColor: transparentBackground }
-        ]}
-        transparent={true}
-        testID="camera-button-tab"
-        aria-selected={isCameraButtonActive}
-        accessibilityLabel="Camera view to save suggestions"
-      />
+      {showCameraButton && (
+        <ImageButton
+          source={
+            CAMERA_SRC[colorScheme][
+              isCameraButtonActive ? 'active' : 'inactive'
+            ]
+          }
+          size={24}
+          onPress={() => switchToTab(AR_UI_TABS.SCREEN_CAPTURE)}
+          style={[
+            styles.cameraButton,
+            { backgroundColor: transparentBackground }
+          ]}
+          transparent={true}
+          testID="camera-button-tab"
+          aria-selected={isCameraButtonActive}
+          accessibilityLabel="Camera view to save suggestions"
+        />
+      )}
+      {isConfirmSuggestionTabActive && (
+        <ThemedView
+          style={[
+            styles.confirmSuggestionContainer,
+            { backgroundColor: '#00000099' }
+          ]}
+          transparent={true}
+        >
+          <Image
+            source={{ uri: suggestions[0].uri }}
+            style={styles.suggestionImage}
+            accessibilityLabel={'Uploaded suggestion'}
+            testID={`uploaded-suggestion`}
+          />
+          <ThemedView
+            style={styles.confirmSuggestionActions}
+            transparent={true}
+          >
+            <TextButton
+              text={'Retake'}
+              type="secondary"
+              onPress={() => {
+                handleSaveSuggestions([]);
+                setCurrentTab(AR_UI_TABS.SCREEN_CAPTURE);
+              }}
+              style={{ backgroundColor: '#ffffff99' }}
+            />
+            <TextButton
+              text={'Save Suggestion'}
+              onPress={() => {
+                closeARModal();
+              }}
+            />
+          </ThemedView>
+        </ThemedView>
+      )}
       {nudgeText && (
         <ThemedView style={styles.nudgeTextContainer}>
           <ThemedText
@@ -190,5 +266,35 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     padding: Spacing.small,
     ...Border.roundedSmall
+  },
+  confirmSuggestionContainer: {
+    // ...Layout.flex,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    ...Layout.center,
+    padding: Spacing.large,
+    // backgroundColor: 'red',
+    // ...Layout.justifyCenter,
+    // ...Layout.alignCenter,
+    zIndex: 1
+  },
+  suggestionImage: {
+    width: '100%',
+    height: '80%',
+    resizeMode: 'cover',
+    // backgroundColor: tamuColors.gray200,
+    // width: '100%',
+    // height: '100%',
+    ...Border.roundedSmall
+  },
+  confirmSuggestionActions: {
+    ...Layout.row,
+    // ...Layout.justifySpaceBetween,
+    ...Layout.center,
+    gap: Spacing.medium,
+    marginTop: Spacing.medium
   }
 });

--- a/codesign/components/augmented-reality/ARUserInterface.tsx
+++ b/codesign/components/augmented-reality/ARUserInterface.tsx
@@ -56,6 +56,7 @@ export function ARUserInterface({
   const nudgeTextColor = useThemeColor({}, 'ARText');
 
   const [currentTab, setCurrentTab] = useState<AR_UI_TAB>(AR_UI_TABS.INITIAL);
+  const [showScreenCapture, setShowScreenCapture] = useState<boolean>(false);
   const [showEntireUI, setShowEntireUI] = useState<boolean>(true);
 
   const suggestionImageOpacity: SharedValue<number> = useSharedValue(0);
@@ -96,14 +97,12 @@ export function ARUserInterface({
     }
     if (tab === AR_UI_TABS.SCREEN_CAPTURE) {
       setCurrentTab(AR_UI_TABS.SCREEN_CAPTURE);
-      // show screen capture UI
       hideItemMenu();
+      setShowScreenCapture(true);
       setNudgeTextWithReset('Take a picture of your creation');
-      // update nudge text
     } else if (tab === AR_UI_TABS.ITEM_MENU) {
       setCurrentTab(AR_UI_TABS.ITEM_MENU);
       showItemMenu();
-      // hide screen capture UI
       maybeHideNudgeText();
     }
   };
@@ -153,8 +152,10 @@ export function ARUserInterface({
           accessibilityLabel="Close Suggestion Modal"
         />
       )}
-      {isCameraButtonActive && (
+      {showScreenCapture && (
         <ScreenshotCapture
+          isVisible={isCameraButtonActive}
+          unmountScreenCapture={() => setShowScreenCapture(false)}
           handleSaveSuggestions={handleSaveSuggestions}
           setShowEntireUI={setShowEntireUI}
           afterScreenshotCallback={() => {
@@ -225,7 +226,7 @@ export function ARUserInterface({
               type="secondary"
               onPress={() => {
                 handleSaveSuggestions([]);
-                setCurrentTab(AR_UI_TABS.SCREEN_CAPTURE);
+                switchToTab(AR_UI_TABS.SCREEN_CAPTURE);
               }}
               style={{ backgroundColor: '#ffffff99' }}
             />

--- a/codesign/components/augmented-reality/ScreenshotCapture.tsx
+++ b/codesign/components/augmented-reality/ScreenshotCapture.tsx
@@ -14,7 +14,7 @@ import { CAPTURE_BUTTON_SRC } from '@/constants/ImagePaths';
 import { convertImageToBase64 } from '@/utils/Image';
 import { ImageDetails } from '@/types/Report';
 
-const SCREENSHOT_WAIT_TIME = 25;
+const SCREENSHOT_WAIT_TIME = 5;
 const CAPTURE_BUTTON_SIZE = 75;
 
 type ScreenshotCaptureProps = {

--- a/codesign/components/augmented-reality/ScreenshotCapture.tsx
+++ b/codesign/components/augmented-reality/ScreenshotCapture.tsx
@@ -63,7 +63,7 @@ export function ScreenshotCapture({
     }, SCREENSHOT_WAIT_TIME);
   };
 
-  const takeScreenshot = async () => {
+  const takeScreenshot = async (afterScreenshotCallback?: () => void) => {
     return await ARSceneRef?.current?.capture?.().then((uri) => {
       createAssetAsync(uri)
         .then((asset: Asset) => {

--- a/codesign/components/augmented-reality/ScreenshotCapture.tsx
+++ b/codesign/components/augmented-reality/ScreenshotCapture.tsx
@@ -134,31 +134,37 @@ function AnimatedScreenCaptureContainer({
   const opacity = useSharedValue(0);
   const translateY = useSharedValue(40);
 
-  useEffect(() => {
-    opacity.value = withTiming(1, {
-      duration: 400,
-      easing: Easing.out(Easing.ease)
-    });
-    translateY.value = withTiming(0, {
-      duration: 400,
-      easing: Easing.out(Easing.ease)
-    });
+  useEffect(
+    () => {
+      opacity.value = withTiming(1, {
+        duration: 400,
+        easing: Easing.out(Easing.ease)
+      });
+      translateY.value = withTiming(0, {
+        duration: 400,
+        easing: Easing.out(Easing.ease)
+      });
+    },
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, []);
+    []
+  );
 
-  if (!isVisible) {
-    opacity.value = withTiming(
-      0,
-      { duration: 400, easing: Easing.out(Easing.ease) },
-      (finished) => {
-        if (finished) runOnJS(unmountScreenCapture)();
-      }
-    );
-    translateY.value = withTiming(40, {
-      duration: 400,
-      easing: Easing.out(Easing.ease)
-    });
-  }
+  useEffect(() => {
+    if (!isVisible) {
+      opacity.value = withTiming(
+        0,
+        { duration: 400, easing: Easing.out(Easing.ease) },
+        (finished) => {
+          if (finished) runOnJS(unmountScreenCapture)();
+        }
+      );
+      translateY.value = withTiming(40, {
+        duration: 400,
+        easing: Easing.out(Easing.ease)
+      });
+    }
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [isVisible, unmountScreenCapture]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: opacity.value,

--- a/codesign/components/augmented-reality/ScreenshotCapture.tsx
+++ b/codesign/components/augmented-reality/ScreenshotCapture.tsx
@@ -18,13 +18,15 @@ const SCREENSHOT_WAIT_TIME = 25;
 const CAPTURE_BUTTON_SIZE = 75;
 
 type ScreenshotCaptureProps = {
-  handleSaveSuggestion: (suggestion: ImageDetails) => void;
+  handleSaveSuggestions: (suggestion: ImageDetails[]) => void;
   setShowEntireUI: (show: boolean) => void;
+  afterScreenshotCallback?: () => void;
 };
 
 export function ScreenshotCapture({
-  handleSaveSuggestion,
-  setShowEntireUI
+  handleSaveSuggestions,
+  setShowEntireUI,
+  afterScreenshotCallback
 }: ScreenshotCaptureProps) {
   const [libraryStatus, requestLibraryPermission] = usePermissions();
 
@@ -45,7 +47,7 @@ export function ScreenshotCapture({
     maybeHideNudgeText();
     setShowEntireUI(false);
     setTimeout(() => {
-      takeScreenshot();
+      takeScreenshot(afterScreenshotCallback);
     }, SCREENSHOT_WAIT_TIME);
   };
 
@@ -53,8 +55,6 @@ export function ScreenshotCapture({
     return await ARSceneRef?.current?.capture?.().then((uri) => {
       createAssetAsync(uri)
         .then((asset: Asset) => {
-          setNudgeTextWithReset('Screenshot saved');
-          setShowEntireUI(true);
           convertImageToBase64(uri)
             .then((base64) => {
               const screenshotImage: ImageDetails = {
@@ -62,7 +62,8 @@ export function ScreenshotCapture({
                 base64: base64
               };
               // Save to form
-              handleSaveSuggestion(screenshotImage);
+              handleSaveSuggestions([screenshotImage]);
+              afterScreenshotCallback?.();
               setShowEntireUI(true);
             })
             .catch(() => {

--- a/codesign/components/report/ImageUpload.tsx
+++ b/codesign/components/report/ImageUpload.tsx
@@ -29,14 +29,11 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { ThemedText } from '@/components/ui/ThemedText';
 import { ImageButton } from '@/components/ui/ImageButton';
 import { ImageDetails } from '@/types/Report';
+import { CLOSE_IMAGE_SRC } from '@/constants/ImagePaths';
 
 export const IMAGE_UPLOAD_LIMIT = 3;
 
 const CONTAINER_HEIGHT = 120;
-const CLOSE_IMAGE_SRC = {
-  light: require('@/assets/images/circle-xmark/circle-xmark-light.png'),
-  dark: require('@/assets/images/circle-xmark/circle-xmark-dark.png')
-};
 const MAX_MB = 20;
 const MAX_IMAGE_SIZE = MAX_MB * 1024 * 1024;
 const MAX_RESOLUTION = 1080;
@@ -367,7 +364,6 @@ const styles = StyleSheet.create({
     height: CONTAINER_HEIGHT
   },
   image: {
-    // ...Layout.flex,
     width: '100%',
     height: '100%',
     ...Border.roundedSmall

--- a/codesign/components/report/SuggestionUpload.tsx
+++ b/codesign/components/report/SuggestionUpload.tsx
@@ -13,6 +13,7 @@ import { ThemedModal } from '@/components/ui/ThemedModal';
 import { ARProvider } from '@/components/augmented-reality/ARProvider';
 import { ARScene } from '@/components/augmented-reality/ARScene';
 import { ARUserInterface } from '@/components/augmented-reality/ARUserInterface';
+import { ImageDetails } from '@/types/Report';
 
 const SPARKLES_SRC = {
   light: require('@/assets/images/sparkles/sparkles-light.png'),
@@ -22,12 +23,12 @@ const SPARKLES_SRC = {
 type SuggestionUploadProps = {
   style?: ViewProps['style'];
   onChange: (...event: any[]) => void;
-  value: string;
+  value: ImageDetails[];
 };
 
 export function SuggestionUpload({
   style,
-  onChange,
+  onChange: saveSuggestionToForm,
   value: suggestion
 }: SuggestionUploadProps) {
   const colorScheme = (useColorScheme() ?? 'light') as 'light' | 'dark';
@@ -64,8 +65,9 @@ export function SuggestionUpload({
           <ARProvider>
             <ARUserInterface
               handleBackButton={handleBackButton}
-              handleSaveSuggestion={() => {
-                // console.log('TODO: Save suggestion');
+              handleSaveSuggestion={(suggestion) => {
+                saveSuggestionToForm([suggestion]);
+                closeARModal();
               }}
             />
             <ARScene />

--- a/codesign/components/report/SuggestionUpload.tsx
+++ b/codesign/components/report/SuggestionUpload.tsx
@@ -46,6 +46,9 @@ export function SuggestionUpload({
     closeARModal();
   };
 
+  const noSuggestions = !suggestions || suggestions.length === 0;
+  const hasSuggestions = suggestions && suggestions.length > 0;
+
   return (
     <ThemedView style={style}>
       <ThemedView style={styles.container}>
@@ -54,7 +57,7 @@ export function SuggestionUpload({
           style={styles.sparklesImage}
           testID="suggestion-sparkles-image"
         />
-        {suggestions && suggestions.length > 0 && (
+        {hasSuggestions && (
           <>
             <ThemedText style={styles.message}>Suggestion Added</ThemedText>
             <ThemedView style={styles.imageContainer}>
@@ -76,7 +79,7 @@ export function SuggestionUpload({
             </ThemedView>
           </>
         )}
-        {(!suggestions || suggestions.length === 0) && (
+        {noSuggestions && (
           <>
             <ThemedText style={styles.message}>
               Suggest an improvement with Augmented Reality
@@ -94,11 +97,12 @@ export function SuggestionUpload({
         <ThemedView style={styles.modalContainer}>
           <ARProvider>
             <ARUserInterface
+              suggestions={suggestions}
               handleBackButton={handleBackButton}
-              handleSaveSuggestion={(suggestion) => {
-                saveSuggestionToForm([suggestion]);
-                closeARModal();
+              handleSaveSuggestions={(suggestions: ImageDetails[]) => {
+                saveSuggestionToForm(suggestions);
               }}
+              closeARModal={closeARModal}
             />
             <ARScene />
           </ARProvider>

--- a/codesign/components/report/SuggestionUpload.tsx
+++ b/codesign/components/report/SuggestionUpload.tsx
@@ -14,11 +14,15 @@ import { ARProvider } from '@/components/augmented-reality/ARProvider';
 import { ARScene } from '@/components/augmented-reality/ARScene';
 import { ARUserInterface } from '@/components/augmented-reality/ARUserInterface';
 import { ImageDetails } from '@/types/Report';
+import { ImageButton } from '@/components/ui/ImageButton';
+import { CLOSE_IMAGE_SRC } from '@/constants/ImagePaths';
 
 const SPARKLES_SRC = {
   light: require('@/assets/images/sparkles/sparkles-light.png'),
   dark: require('@/assets/images/sparkles/sparkles-dark.png')
 };
+
+const SUGGESTION_IMAGE_HEIGHT = 90;
 
 type SuggestionUploadProps = {
   style?: ViewProps['style'];
@@ -29,7 +33,7 @@ type SuggestionUploadProps = {
 export function SuggestionUpload({
   style,
   onChange: saveSuggestionToForm,
-  value: suggestion
+  value: suggestions
 }: SuggestionUploadProps) {
   const colorScheme = (useColorScheme() ?? 'light') as 'light' | 'dark';
   const {
@@ -50,10 +54,36 @@ export function SuggestionUpload({
           style={styles.sparklesImage}
           testID="suggestion-sparkles-image"
         />
-        <ThemedText style={styles.message}>
-          Would you like to suggest an improvement?
-        </ThemedText>
-        <TextButton type="secondary" text="SUGGEST" onPress={openARModal} />
+        {suggestions && suggestions.length > 0 && (
+          <>
+            <ThemedText style={styles.message}>Suggestion Added</ThemedText>
+            <ThemedView style={styles.imageContainer}>
+              <ImageButton
+                source={CLOSE_IMAGE_SRC[colorScheme]}
+                size={24}
+                transparent={true}
+                style={styles.removeImageButton}
+                onPress={() => saveSuggestionToForm([])}
+                accessibilityLabel={`Remove suggestion`}
+                testID="remove-suggestion-button"
+              />
+              <Image
+                source={{ uri: suggestions[0].uri }}
+                style={styles.image}
+                accessibilityLabel={'Uploaded suggestion'}
+                testID={`uploaded-suggestion`}
+              />
+            </ThemedView>
+          </>
+        )}
+        {(!suggestions || suggestions.length === 0) && (
+          <>
+            <ThemedText style={styles.message}>
+              Suggest an improvement with Augmented Reality
+            </ThemedText>
+            <TextButton type="secondary" text="SUGGEST" onPress={openARModal} />
+          </>
+        )}
       </ThemedView>
 
       <ThemedModal
@@ -102,5 +132,24 @@ const styles = StyleSheet.create({
   },
   modalContainer: {
     ...Layout.flex
+  },
+  imageContainer: {
+    ...Layout.flex,
+    ...Layout.absolute,
+    ...Border.elevatedSmall,
+    ...Border.roundedSmall,
+    width: 'auto',
+    height: SUGGESTION_IMAGE_HEIGHT
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    ...Border.roundedSmall
+  },
+  removeImageButton: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    zIndex: 1
   }
 });

--- a/codesign/constants/ImagePaths.ts
+++ b/codesign/constants/ImagePaths.ts
@@ -1,3 +1,8 @@
+export const CLOSE_IMAGE_SRC = {
+  light: require('@/assets/images/circle-xmark/circle-xmark-light.png'),
+  dark: require('@/assets/images/circle-xmark/circle-xmark-dark.png')
+};
+
 export const CHEVRON_LEFT_SRC = {
   light: require('@/assets/images/back-arrow.png'),
   dark: require('@/assets/images/back-arrow.png')

--- a/codesign/constants/report/Report.ts
+++ b/codesign/constants/report/Report.ts
@@ -19,7 +19,8 @@ export const DefaultIndoorReport: ReportFormDetails = {
   },
   coordinates: ALBRITTON_BELL_TOWER,
   createdAt: new Date(),
-  images: []
+  images: [],
+  suggestions: []
 };
 
 export const DefaultOutdoorReport: ReportFormDetails = {
@@ -31,5 +32,6 @@ export const DefaultOutdoorReport: ReportFormDetails = {
   reportLocationDetails: {},
   coordinates: ALBRITTON_BELL_TOWER,
   createdAt: new Date(),
-  images: []
+  images: [],
+  suggestions: []
 };

--- a/codesign/mocks/mockImage.tsx
+++ b/codesign/mocks/mockImage.tsx
@@ -3,10 +3,10 @@
  * Provides utilities for loading and converting test images to base64
  */
 
-import { readAsStringAsync, EncodingType } from 'expo-file-system';
 import { Asset } from 'expo-asset';
 
 import { getRandomInt } from '@/utils/Math';
+import { convertImageToBase64 } from '@/utils/Image';
 
 const DEFAULT_IMAGES = [
   require('@/assets/images/default/corner.png'),
@@ -26,15 +26,3 @@ export async function getMockImage() {
     throw new Error('Error getting mock image');
   }
 }
-
-/** Helper function to convert image file to base64 string */
-const convertImageToBase64 = async (fileUri: string) => {
-  try {
-    const base64Data = await readAsStringAsync(fileUri, {
-      encoding: EncodingType.Base64
-    });
-    return base64Data;
-  } catch {
-    throw new Error('Error converting image to base 64');
-  }
-};

--- a/codesign/utils/Image.ts
+++ b/codesign/utils/Image.ts
@@ -1,3 +1,5 @@
+import { readAsStringAsync, EncodingType } from 'expo-file-system';
+
 import { ImageDetails } from '@/types/Report';
 
 export const getImageSrc = (
@@ -17,4 +19,16 @@ export const getImageSrc = (
 
 type ImageSource = {
   uri: string;
+};
+
+/** Helper function to convert image file to base64 string */
+export const convertImageToBase64 = async (fileUri: string) => {
+  try {
+    const base64Data = await readAsStringAsync(fileUri, {
+      encoding: EncodingType.Base64
+    });
+    return base64Data;
+  } catch {
+    throw new Error('Error converting image to base 64');
+  }
 };


### PR DESCRIPTION
Resolve # 121

# Summary
Save AR suggestion (screenshot image) to the report form

# Description
- [x] Allow screenshot of AR to be saved, converted into both uri and base64, and saved to the report.
- [x] Before saving screenshot to report, show a preview, to allow the user to retake the image if they do not like it.
- [x] Add animations for screen capture (slide up and down) and image preview (fade in)
- [x] When screenshot is saved to report, show an image of it (similar to ImageUpload component).

# Testing
Demo that verifies the following behavior:

Main flow
- [x] 3D objects can be added to scene
- [x] Take a picture of the scene
- [x] Show a preview of the screenshot
- [x] Screenshot is saved to the report form

https://github.com/user-attachments/assets/88bb16a0-6ce4-430d-8460-30863db4fb10

Corner cases
- [x] Pressing Retake will return to the same scene
- [x] Pressing back button in top left will not save any photo
- [x] Retaking another photo can be successfully saved
- [x] Tapping 'X' on saved suggestion will remove it and allow another suggestion to be created

https://github.com/user-attachments/assets/badf9d50-2e58-473f-877e-20c1ff1675e4


