### PR TITLE
Switch order of location selection map and indoor/outdoor radio buttons

### DIFF
--- a/codesign/components/__tests__/report/ReportForm-test.tsx
+++ b/codesign/components/__tests__/report/ReportForm-test.tsx
@@ -63,7 +63,10 @@ describe('<ReportForm />', () => {
 
     // Location section should be visible
     await waitFor(() => {
-      expect(screen.getByText('Location')).toBeVisible();
+      expect(screen.getByText('Location Details')).toBeVisible();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Issue Location*')).toBeVisible();
     });
     await waitFor(() => {
       expect(screen.getByText('Indoor')).toBeVisible();

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -146,8 +146,22 @@ export function ReportForm({ style }: ViewProps) {
           withDivider={true}
           style={{ marginBottom: Spacing.small }}
         >
-          Location
+          Location Details
         </ThemedText>
+        <ThemedView style={styles.input}>
+          <Controller
+            control={control}
+            name="coordinates"
+            rules={VALIDATION_RULES.coordinates}
+            render={({ field: { onChange, value } }) => (
+              <SelectLocation
+                setSelectedLocation={onChange}
+                selectedLocation={value}
+                errorText={errors.coordinates?.message}
+              />
+            )}
+          />
+        </ThemedView>
         <ThemedView style={styles.input}>
           <Controller
             control={control}
@@ -156,6 +170,10 @@ export function ReportForm({ style }: ViewProps) {
             rules={VALIDATION_RULES.reportLocation}
             render={({ field: { onChange, value } }) => (
               <>
+                <ThemedText type={'formText'}>
+                  Issue Location
+                  <ThemedText type="error">*</ThemedText>
+                </ThemedText>
                 {errors.reportLocation && (
                   <ThemedText type="error">
                     {errors.reportLocation.message}
@@ -185,22 +203,6 @@ export function ReportForm({ style }: ViewProps) {
             )}
           />
         </ThemedView>
-
-        <ThemedView style={styles.input}>
-          <Controller
-            control={control}
-            name="coordinates"
-            rules={VALIDATION_RULES.coordinates}
-            render={({ field: { onChange, value } }) => (
-              <SelectLocation
-                setSelectedLocation={onChange}
-                selectedLocation={value}
-                errorText={errors.coordinates?.message}
-              />
-            )}
-          />
-        </ThemedView>
-
         {reportLocation === ReportLocationType.INDOOR && (
           <>
             <ThemedView style={styles.input}>

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -170,7 +170,7 @@ export function ReportForm({ style }: ViewProps) {
             rules={VALIDATION_RULES.reportLocation}
             render={({ field: { onChange, value } }) => (
               <>
-                <ThemedText type={'formText'}>
+                <ThemedText type={'formText'} id="issue-location-label">
                   Issue Location
                   <ThemedText type="error">*</ThemedText>
                 </ThemedText>
@@ -179,26 +179,31 @@ export function ReportForm({ style }: ViewProps) {
                     {errors.reportLocation.message}
                   </ThemedText>
                 )}
-                <ThemedRadioButton
-                  title="Indoor"
-                  checked={value === ReportLocationType.INDOOR}
-                  onPress={() =>
-                    maybeSwitchLocationAlert(
-                      ReportLocationType.INDOOR,
-                      onChange
-                    )
-                  }
-                />
-                <ThemedRadioButton
-                  title="Outdoor"
-                  checked={value === ReportLocationType.OUTDOOR}
-                  onPress={() =>
-                    maybeSwitchLocationAlert(
-                      ReportLocationType.OUTDOOR,
-                      onChange
-                    )
-                  }
-                />
+                <ThemedView
+                  role="radiogroup"
+                  aria-labelledby="issue-location-label"
+                >
+                  <ThemedRadioButton
+                    title="Indoor"
+                    checked={value === ReportLocationType.INDOOR}
+                    onPress={() =>
+                      maybeSwitchLocationAlert(
+                        ReportLocationType.INDOOR,
+                        onChange
+                      )
+                    }
+                  />
+                  <ThemedRadioButton
+                    title="Outdoor"
+                    checked={value === ReportLocationType.OUTDOOR}
+                    onPress={() =>
+                      maybeSwitchLocationAlert(
+                        ReportLocationType.OUTDOOR,
+                        onChange
+                      )
+                    }
+                  />
+                </ThemedView>
               </>
             )}
           />

--- a/codesign/components/report/SelectLocation.tsx
+++ b/codesign/components/report/SelectLocation.tsx
@@ -238,7 +238,8 @@ const styles = StyleSheet.create({
   previewContainer: {
     height: PREVIEW_HEIGHT,
     ...Border.roundedLarge,
-    ...Border.elevatedSmall
+    ...Border.elevatedSmall,
+    marginTop: Spacing.large
   },
   roundCorner: {
     ...Layout.flex,

--- a/codesign/components/ui/ThemedRadioButton.tsx
+++ b/codesign/components/ui/ThemedRadioButton.tsx
@@ -56,6 +56,9 @@ export function ThemedRadioButton({
           {title}
         </ThemedText>
       }
+      aria-label={title}
+      role="radio"
+      aria-checked={checked}
       checked={checked}
       onPress={onPress}
       checkedIcon={

--- a/codesign/docs/03-testing.md
+++ b/codesign/docs/03-testing.md
@@ -1,37 +1,41 @@
 # Testing
 
 - Unit and Component Tests
-    - How to Run
-    - Debugging
-    - Mocking 3rd Party Libraries
+  - How to Run
+  - Debugging
+  - Mocking 3rd Party Libraries
 - Acceptance Tests
-    - Environment Setup
-    - How to Run
-
+  - Environment Setup
+  - How to Run
 
 # Unit and Component Testing
+
 CoDesign leverages 2 testing libraries for unit and component testing:
 
-  - [Jest](https://jestjs.io/docs/getting-started)
-  - [React Native Testing Library](https://testing-library.com/docs/react-native-testing-library/intro/)
+- [Jest](https://jestjs.io/docs/getting-started)
+- [React Native Testing Library](https://testing-library.com/docs/react-native-testing-library/intro/)
 
-All test files can be found in the __tests__ folder relative to the source files. For example, all component tests are in the components/__tests__/ folder and all api tests are in the api/__tests__ folder.
+All test files can be found in the **tests** folder relative to the source files. For example, all component tests are in the components/**tests**/ folder and all api tests are in the api/**tests** folder.
 
 ### How to Run
+
 We recommend running tests in the JavaScript Debug Terminal in VSCode. A debugger process will automatically be attached. [Where to Find JavaScript Debug Terminal](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_javascript-debug-terminal)
 
 To run tests, paste the following command:
+
 ```
 npm run test
 ```
 
 ### Debugging
+
 Once you run the command in the JavaScript Debug Terminal, you can:
 
 - [Set breakpoints to debug](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_breakpoints)
 - Run only specific tests: Jest CLI will provide you a list of options, including 't' to filter by testname pattern and 'p' to filter by filename pattern
 
 ### Mocking 3rd Party Libraries
+
 If you are testing a component that leverages a 3rd party library, you may have to mock that library and its imports. This keeps tests fast and predictable.
 
 Example: While testing a component that leverages the '@rnmapbox/maps' library, the following mock must be set up before importing the component:
@@ -106,16 +110,16 @@ Codesign uses [Maestro](https://docs.maestro.dev/) for end-to-end testing, which
 - Maestro requires a Java Runtime Environment: [Download Java 11 for Mac](https://www.oracle.com/java/technologies/downloads/?er=221886#java11-mac)
 - Running `maestro` in the terminal should now successfully display maestro list of commands
 
-
 # How to Run E2E Tests
 
-  - **Pre-requisite: Build Codesign and install to Simulator** - In terminal, run `npm run ios` to build and run Codesign on the iOS Simulator.
+- **Pre-requisite: Build Codesign and install to Simulator** - In terminal, run `npm run ios` to build and run Codesign on the iOS Simulator.
 
-  - **Run Maestro test:** `maestro test e2e/create-and-view-report.yaml` Maestro run the test using the simulator that was opened in the previous step and output each step.
-
+- **Run Maestro test:** `maestro test e2e/fill-report-form.yaml` Maestro run the test using the simulator that was opened in the previous step and output each step.
 
 # Debugging
+
 [Maestro Studio](https://docs.maestro.dev/getting-started/maestro-studio) provides helpful tools to run test commands and for debugging. Ensure to have Codesign open on the iOS Simulator, then in a separate terminal, run:
+
 ```
 maestro studio
 ```

--- a/codesign/e2e/fill-report-form.yaml
+++ b/codesign/e2e/fill-report-form.yaml
@@ -9,16 +9,6 @@ appId: com.urbanailab.codesign
 # When tap on the "Create Report" tab
 - tapOn: Create Report, tab, 2 of 3
 
-# Location options should be visible
-- assertVisible: "Location"
-- assertVisible: "Indoor"
-- assertVisible: "Outdoor"
-
-# and indoor fields
-- assertVisible: "Building Name*"
-- assertVisible: "Floor Number*"
-- assertVisible: 1
-
 # When interact with map
 - tapOn:
     id: mapbox-mapview
@@ -39,10 +29,20 @@ appId: com.urbanailab.codesign
 - assertNotVisible: "Use Current Location"
 - assertNotVisible: "Set Location"
 
+# Location options should be visible
+- assertVisible: "Issue Location*"
+- assertVisible: "Indoor"
+- assertVisible: "Outdoor"
+
+# and indoor fields
+- assertVisible: "Building Name*"
+- assertVisible: "Floor Number*"
+- assertVisible: 1
+
 # and fill in the Build Name
 - tapOn: "Enter building name"
 - inputText: "Test Building"
-- tapOn: "Location" # close keyboard without using flakey hideKeyboard
+- tapOn: "Issue Location*" # close keyboard without using flakey hideKeyboard
 
 # Then, switching to Outdoor should trigger confirmation alert
 - tapOn: "Outdoor"


### PR DESCRIPTION
Resolve #134 

# Summary
After having multiple users un-intentionally skip the location selection component, we received feedback to make it show up first.

# Description
- Switch the order of the location selection map and indoor/outdoor fields
- Rename "Location" title to "Location Details" 
- Give Radio buttons a label called "Issue Location"
- Update acceptance test with label changes

# Testing
- Update report form test, `npm run test` passes
- Update automated e2e test with new label names, it passes

| Before | After  |
|-------|-------|
|<img width="200" alt="Screenshot 2025-07-23 at 12 24 29 PM" src="https://github.com/user-attachments/assets/daf63f3c-729f-4102-a3a5-acc9938e69d8" /> | <img width="200" alt="Screenshot 2025-07-23 at 12 13 18 PM" src="https://github.com/user-attachments/assets/ff58925a-9789-4c2d-bcc0-b94109d8be7d" />|

