### PR TITLE
Show either indoor or outdoor items depending on Report Form

### DIFF
--- a/codesign/components/augmented-reality/ARScene.tsx
+++ b/codesign/components/augmented-reality/ARScene.tsx
@@ -5,10 +5,14 @@ import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import { Layout } from '@/constants/styles/Layout';
 import { useARContext } from '@/components/augmented-reality/ARProvider';
 import { AR_ITEMS, AR_ITEM_NAMES } from '@/constants/augmented-reality/Items';
+import { ReportLocationType } from '@/types/Report';
 
-const AR_SCENE_PROD_URL = 'https://tamucodesign.8thwall.app/tap-menu/';
-
-export function ARScene() {
+export function ARScene({
+  currentLocation
+}: {
+  currentLocation: ReportLocationType;
+}) {
+  const AR_SCENE_PROD_URL = `https://tamucodesign.8thwall.app/tap-menu/?location=${currentLocation}`;
   const { setNudgeTextWithReset, webViewRef, ARSceneRef } = useARContext();
 
   const handleWebViewMessage = (event: WebViewMessageEvent) => {

--- a/codesign/components/report/ReportForm.tsx
+++ b/codesign/components/report/ReportForm.tsx
@@ -277,6 +277,7 @@ export function ReportForm({ style }: ViewProps) {
             name="suggestions"
             render={({ field: { onChange, value } }) => (
               <SuggestionUpload
+                currentLocation={reportLocation}
                 value={value}
                 onChange={onChange}
                 style={{ marginTop: Spacing.xsmall }}

--- a/codesign/components/report/SuggestionUpload.tsx
+++ b/codesign/components/report/SuggestionUpload.tsx
@@ -16,6 +16,7 @@ import { ARUserInterface } from '@/components/augmented-reality/ARUserInterface'
 import { ImageDetails } from '@/types/Report';
 import { ImageButton } from '@/components/ui/ImageButton';
 import { CLOSE_IMAGE_SRC } from '@/constants/ImagePaths';
+import { ReportLocationType } from '@/types/Report';
 
 const SPARKLES_SRC = {
   light: require('@/assets/images/sparkles/sparkles-light.png'),
@@ -25,12 +26,14 @@ const SPARKLES_SRC = {
 const SUGGESTION_IMAGE_HEIGHT = 90;
 
 type SuggestionUploadProps = {
+  currentLocation: ReportLocationType;
   style?: ViewProps['style'];
   onChange: (...event: any[]) => void;
   value: ImageDetails[];
 };
 
 export function SuggestionUpload({
+  currentLocation,
   style,
   onChange: saveSuggestionToForm,
   value: suggestions
@@ -104,7 +107,7 @@ export function SuggestionUpload({
               }}
               closeARModal={closeARModal}
             />
-            <ARScene />
+            <ARScene currentLocation={currentLocation} />
           </ARProvider>
         </ThemedView>
       </ThemedModal>

--- a/codesign/constants/augmented-reality/Items.ts
+++ b/codesign/constants/augmented-reality/Items.ts
@@ -1,7 +1,19 @@
 export const AR_ITEMS = {
   TRASH: 'Trash',
   BUS_STOP: 'Bus Stop',
-  BENCH: 'Bench',
+  LARGE_PLANT: 'Large Plant',
+  SUCCULENT: 'Succulent',
+  CLASSIC_BENCH: 'Classic Bench',
+  MODERN_BENCH: 'Modern Bench',
+  BENCH_WITH_GREENERY: 'Bench with Greenery',
+  PICNIC_TABLE: 'Picnic Table',
+  STREET_LAMP: 'Street Lamp',
+  CHAIR: 'Chair',
+  VENDING_MACHINE: 'Vending Machine',
+  TABLE: 'Table',
+  ARM_CHAIR: 'Arm Chair',
+  DRINKING_FOUNTAIN: 'Drinking Fountain',
+  PLANT: 'Plant',
   REMOVE: 'Remove'
 };
 


### PR DESCRIPTION
Resolve #120

# Summary
Before, CoDesign would automatically show only outdoor items. Now, if the report location is set to indoor, 

it will show indoor items (chair, water fountain, etc) and when report location is set to OUTDOOR, it will show outdoor items (bus stop, etc).

# Description
- Use query param to show correct item type
- Add item copy to the nudge message

# Testing
npm run test passes

Manually check indoor versus outdoor selections

| Outdoor Menu | Indoor Menu  |
|-------|-------|
|<img width="200" alt="Screenshot 2025-07-23 at 12 24 29 PM" src="https://github.com/user-attachments/assets/f2415625-1122-4876-9d1f-d40590594c79" /> | <img width="200" alt="Screenshot 2025-07-23 at 12 13 18 PM" src="https://github.com/user-attachments/assets/ba42cd42-5dab-42da-ad68-46874d9d8e22" />|
